### PR TITLE
docs: add license section

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,6 +423,10 @@ Future work is tracked in [ROADMAP.md](ROADMAP.md). Concrete tasks should become
 GitHub issues before implementation, especially if they change the public API or
 generated YAML.
 
+## LICENSE
+
+MIT.
+
 ## Development
 
 ```bash


### PR DESCRIPTION
# Pull Request

## Summary

**What changed:**

Added a small `LICENSE` section to the README.

**Why:**

The package landing page should state the project license directly.

> [!IMPORTANT]
> Keep reviewed diffs small. If this adds more than 500 lines outside generated files or lockfiles, split it.

**Lines added, excluding generated files and lockfiles:** 4

## Test Plan

- [ ] CLA/Vouch check passes, or this PR only updates `VOUCHED.td`
- [ ] `npm run lint`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run build`
- [ ] `npm run check`
- [ ] `npm run package`

Manual verification:

- `git diff --stat origin/main...HEAD`
- `git diff --name-only origin/main...HEAD`

## Generated Output

N/A

## Repro / Showcase

N/A - README-only text change.

## Release Impact

- [ ] Runtime/library behavior changed
- [ ] CLI behavior changed
- [ ] Generated YAML changed
- [ ] Package contents changed
- [x] Documentation only
- [ ] N/A

## Compatibility

N/A

## Reviewers

- Domain: @windsornguyen
- Readability: @windsornguyen

## Notes for Reviewers

Tiny README-only license note.

## Changelog

**[2026-06-16]**

Feedback received:

- (none yet)

Changes made:

- Initial implementation
