### PR TITLE
fix(gha): trust cind bot rename

### DIFF
--- a/.github/workflows/flowers.yml
+++ b/.github/workflows/flowers.yml
@@ -8,8 +8,6 @@ on:
   workflow_dispatch: {}
 permissions:
   contents: read
-  issues: write
-  pull-requests: read
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 jobs:
@@ -28,7 +26,18 @@ jobs:
         run: npm ci
       - name: Build Hollywood
         run: npm run build
+      - id: cind-token
+        name: Create Cind app token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1
+        with:
+          app-id: ${{ secrets.CIND_BOT_APP_ID }}
+          private-key: ${{ secrets.CIND_BOT_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: hollywood
+          permission-issues: write
+          permission-metadata: read
+          permission-pull-requests: read
       - name: Leave flower comment
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ steps.cind-token.outputs.token }}
         run: node dist/cli.js run gha/flowers.ts --export leaveFlower --with eventPath="$GITHUB_EVENT_PATH" --with repository="$GITHUB_REPOSITORY" --with token="$GITHUB_TOKEN"

--- a/gha/flowers.ts
+++ b/gha/flowers.ts
@@ -2,7 +2,7 @@ import { action, job, pathInput, stringInput, workflow, type ScriptExec } from "
 import { checkoutAction, setupNodeAction } from "./actions";
 
 const flowerBody = "Here's a flower for all your hard work! 🌸";
-const flowerBots = new Set(["github-actions[bot]", "cind-bot[bot]"]);
+const flowerBots = new Set(["github-actions[bot]", "cind-bot[bot]", "cind[bot]"]);
 
 type PushEvent = Readonly<{
 	after?: unknown;

--- a/gha/flowers.ts
+++ b/gha/flowers.ts
@@ -1,5 +1,5 @@
 import { action, job, pathInput, stringInput, workflow, type ScriptExec } from "../src/index";
-import { checkoutAction, setupNodeAction } from "./actions";
+import { checkoutAction, createGitHubAppTokenAction, setupNodeAction } from "./actions";
 
 const flowerBody = "Here's a flower for all your hard work! 🌸";
 const flowerBots = new Set(["github-actions[bot]", "cind-bot[bot]", "cind[bot]"]);
@@ -145,8 +145,6 @@ export const flowers = workflow({
 	},
 	permissions: {
 		contents: "read",
-		issues: "write",
-		"pull-requests": "read",
 	},
 	env: {
 		FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true",
@@ -162,9 +160,23 @@ export const flowers = workflow({
 				{ name: "Install dependencies", run: "npm ci" },
 				{ name: "Build Hollywood", run: "npm run build" },
 				{
+					id: "cind-token",
+					name: "Create Cind app token",
+					uses: createGitHubAppTokenAction,
+					with: {
+						"app-id": "${{ secrets.CIND_BOT_APP_ID }}",
+						"private-key": "${{ secrets.CIND_BOT_APP_PRIVATE_KEY }}",
+						owner: "${{ github.repository_owner }}",
+						repositories: "hollywood",
+						"permission-issues": "write",
+						"permission-metadata": "read",
+						"permission-pull-requests": "read",
+					},
+				},
+				{
 					name: "Leave flower comment",
 					env: {
-						GITHUB_TOKEN: "${{ github.token }}",
+						GITHUB_TOKEN: "${{ steps.cind-token.outputs.token }}",
 					},
 					run: 'node dist/cli.js run gha/flowers.ts --export leaveFlower --with eventPath="$GITHUB_EVENT_PATH" --with repository="$GITHUB_REPOSITORY" --with token="$GITHUB_TOKEN"',
 				},


### PR DESCRIPTION
# Pull Request

## Summary

**What changed:**

Hollywood's merged-PR flower workflow now mints a Cind GitHub App token before posting PR comments, and the flower action treats both `cind-bot[bot]` and `cind[bot]` as bot authors when deduplicating comments.

**Why:**

The `main` flower run failed with `gh: Resource not accessible by integration (HTTP 403)` while posting an issue comment with `GITHUB_TOKEN`. Using the Cind app token gives the trusted `push` workflow the explicit `issues: write` and `pull-requests: read` authority it needs, while keeping the default workflow token read-only.

> [!IMPORTANT]
> Keep reviewed diffs small. If this adds more than 500 lines outside generated files or lockfiles, split it.

**Lines added, excluding generated files and lockfiles:** +17

## Test Plan

- [ ] CLA/Vouch check passes, or this PR only updates `VOUCHED.td`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test`
- [x] `npm run build`
- [x] `npm run check`
- [x] `npm run package`

Also ran `npm run generate`; it updated `.github/workflows/flowers.yml` from the typed `gha/flowers.ts` source.

## Generated Output

`.github/workflows/flowers.yml` now creates a Cind app token before the comment step:

```yaml
- id: cind-token
  name: Create Cind app token
  uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1
  with:
    app-id: ${{ secrets.CIND_BOT_APP_ID }}
    private-key: ${{ secrets.CIND_BOT_APP_PRIVATE_KEY }}
    owner: ${{ github.repository_owner }}
    repositories: hollywood
    permission-issues: write
    permission-metadata: read
    permission-pull-requests: read
- name: Leave flower comment
  env:
    GITHUB_TOKEN: ${{ steps.cind-token.outputs.token }}
```

## Repro / Showcase

Failing run inspected: https://github.com/dedalus-labs/hollywood/actions/runs/27643660692/job/81749916139

The failure was:

```txt
gh: Resource not accessible by integration (HTTP 403)
POST repos/dedalus-labs/hollywood/issues/<pr>/comments
```

Verified with GitHub API:

- `/apps/cind-bot` reports `name: "cind[bot]"` and `slug: "cind-bot"`.
- `/users/cind-bot[bot]` resolves.
- `/users/cind[bot]` is currently 404.

## Release Impact

- [ ] Runtime/library behavior changed
- [ ] CLI behavior changed
- [x] Generated YAML changed
- [ ] Package contents changed
- [ ] Documentation only
- [ ] N/A

## Compatibility

No breaking package API change. The workflow now requires the existing `CIND_BOT_APP_ID` and `CIND_BOT_APP_PRIVATE_KEY` repository secrets that the release workflow already uses.

## Reviewers

- Domain: @windsornguyen
- Readability: @AgentWings

## Notes for Reviewers

This PR intentionally keeps the workflow on trusted `push` to `main`; it does not introduce `pull_request_target` or expose secrets to fork PR code. The app token is minted after checkout/build and is scoped to `hollywood` with metadata read, pull requests read, and issues write.

## Changelog

**[2026-06-16]**

Feedback received:

- Flower workflow on `main` failed with `GITHUB_TOKEN` comment permissions.

Changes made:

- Mint a Cind app token for the flower comment step.
- Keep workflow `GITHUB_TOKEN` at `contents: read`.
- Trust both current and renamed Cind bot logins for duplicate detection.