### PR TITLE
fix(gha): request write pr token for flowers

### DIFF
--- a/.github/workflows/flowers.yml
+++ b/.github/workflows/flowers.yml
@@ -34,9 +34,8 @@ jobs:
           private-key: ${{ secrets.CIND_BOT_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: hollywood
-          permission-issues: write
           permission-metadata: read
-          permission-pull-requests: read
+          permission-pull-requests: write
       - name: Leave flower comment
         env:
           GITHUB_TOKEN: ${{ steps.cind-token.outputs.token }}

--- a/gha/flowers.ts
+++ b/gha/flowers.ts
@@ -168,9 +168,8 @@ export const flowers = workflow({
 						"private-key": "${{ secrets.CIND_BOT_APP_PRIVATE_KEY }}",
 						owner: "${{ github.repository_owner }}",
 						repositories: "hollywood",
-						"permission-issues": "write",
 						"permission-metadata": "read",
-						"permission-pull-requests": "read",
+						"permission-pull-requests": "write",
 					},
 				},
 				{


### PR DESCRIPTION
# Pull Request

## Summary

**What changed:**

The merged-PR flower workflow now requests `pull-requests: write` on the Cind GitHub App token and stops requesting `issues: write` for the comment step.

**Why:**

The post-merge run for #12 still failed at `POST /issues/<pr>/comments` with `Resource not accessible by integration (HTTP 403)` even though the Cind token was minted successfully. GitHub documents the create issue comment endpoint as accepting `Pull requests: write`; requesting that directly matches the PR-comment use case.

> [!IMPORTANT]
> Keep reviewed diffs small. If this adds more than 500 lines outside generated files or lockfiles, split it.

**Lines added, excluding generated files and lockfiles:** +1

## Test Plan

- [ ] CLA/Vouch check passes, or this PR only updates `VOUCHED.td`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test`
- [x] `npm run build`
- [x] `npm run check`
- [x] `npm run package`

Also ran `npm run generate`; it updated `.github/workflows/flowers.yml` from `gha/flowers.ts`.

## Generated Output

```yaml
permission-metadata: read
permission-pull-requests: write
```

## Repro / Showcase

The post-merge flower run for #12 still failed after creating a Cind token:

https://github.com/dedalus-labs/hollywood/actions/runs/27646211735

Relevant log:

```txt
Create Cind app token ... success
permission-issues: write
permission-metadata: read
permission-pull-requests: read
...
gh: Resource not accessible by integration (HTTP 403)
```

## Release Impact

- [ ] Runtime/library behavior changed
- [ ] CLI behavior changed
- [x] Generated YAML changed
- [ ] Package contents changed
- [ ] Documentation only
- [ ] N/A

## Compatibility

No package API change. This only changes the repository workflow's GitHub App token permission request.

## Reviewers

- Domain: @windsornguyen
- Readability: @AgentWings

## Notes for Reviewers

This remains a trusted `push` to `main` workflow. No `pull_request_target` or fork PR secret exposure is introduced.

## Changelog

**[2026-06-16]**

Feedback received:

- Post-merge flower run still failed after #12.

Changes made:

- Request `pull-requests: write` for the Cind token used to post the PR comment.
- Remove the separate `issues: write` request.