### PR TITLE
fix(security): add GitHub private vulnerability reporting

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,6 +6,8 @@ Do not open public issues for security vulnerabilities.
 
 Email security reports to [security@dedaluslabs.ai](mailto:security@dedaluslabs.ai).
 
+You can also [report privately via GitHub](https://github.com/dedalus-labs/hollywood/security/advisories/new).
+
 Include:
 
 - Description of the vulnerability


### PR DESCRIPTION
# Pull Request

## Summary

**What changed:**

Add GitHub private vulnerability reporting link to SECURITY.md alongside the existing security email.

**Why:**

Reporters can use GitHub's built-in private advisory flow instead of email. Lower friction, better audit trail, no email exposure required.

**Lines added, excluding generated files and lockfiles:** +2

## Test Plan

- [x] CLA/Vouch check passes, or this PR only updates `VOUCHED.td`
- [ ] `npm run lint`
- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run build`
- [ ] `npm run check`
- [ ] `npm run package`

## Generated Output

N/A

## Repro / Showcase

N/A

## Release Impact

- [x] Documentation only

## Compatibility

N/A

## Reviewers

- Domain: @windsornguyen
- Readability: @windsornguyen

## Notes for Reviewers

Requires enabling "Private vulnerability reporting" in repo Settings > Security > Code security and analysis.

## Changelog

**[2026-06-21]**

Feedback received:

- (none yet)

Changes made:

- Add GitHub private reporting link to SECURITY.md