### PR TITLE
test(github): inline readable log action

### DIFF
--- a/src/github.test.ts
+++ b/src/github.test.ts
@@ -114,7 +114,8 @@ test("runGitHubAction binds core inputs, execs commands, and sets outputs", asyn
 
 test("runGitHubAction groups exec logs with command metadata and status", async () => {
 	const events: string[] = [];
-	const readableAction = action({
+
+	await runGitHubAction(action({
 		name: "readable-action",
 		description: "Exercise readable command logs.",
 		inputs: {},
@@ -131,9 +132,7 @@ test("runGitHubAction groups exec logs with command metadata and status", async 
 			});
 			return { status: "ok" };
 		},
-	});
-
-	await runGitHubAction(readableAction, {
+	}), {
 		core: {
 			getInput: () => "",
 			group: async (name, run) => {
@@ -160,9 +159,8 @@ test("runGitHubAction groups exec logs with command metadata and status", async 
 	assert.equal(events[1], "info:\u001B[2m  cwd  /repo\u001B[0m");
 	assert.equal(events[2], "info:\u001B[2m  env  ALPHA, ZETA\u001B[0m");
 	const status = events[3] ?? "";
-	const statusPrefix = "info:  \u001B[32mok\u001B[0m";
-	assert.ok(status.startsWith(statusPrefix));
-	assert.match(status.slice(statusPrefix.length), /^\s+\d+ms  tool 'hello world' 'it'\\''s'$/);
+	assert.ok(status.startsWith("info:  \u001B[32mok\u001B[0m"));
+	assert.match(status, /\s+\d+ms  tool 'hello world' 'it'\\''s'$/);
 	assert.equal(events[4], "output:status:ok");
 });
 


### PR DESCRIPTION
# Pull Request

## Summary

**What changed:**

Inline the one-off readable-log action fixture in `src/github.test.ts` and keep the status assertion direct.

**Why:**

The helper was only used once, so inlining keeps the test smaller while preserving the readable ANSI/timing assertions.

> [!IMPORTANT]
> Keep reviewed diffs small. If this adds more than 500 lines outside generated files or lockfiles, split it.

**Lines added, excluding generated files and lockfiles:** 5

## Test Plan

- [ ] CLA/Vouch check passes, or this PR only updates `VOUCHED.td`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run build`
- [ ] `npm run check`
- [ ] `npm run package`

Also ran:

```bash
npm test -- src/github.test.ts
```

## Generated Output

N/A

## Repro / Showcase

N/A

## Release Impact

- [ ] Runtime/library behavior changed
- [ ] CLI behavior changed
- [ ] Generated YAML changed
- [ ] Package contents changed
- [ ] Documentation only
- [x] N/A

## Compatibility

N/A

## Reviewers

- Domain: @windsornguyen
- Readability: @windsornguyen

## Notes for Reviewers

Test-only cleanup after #18. The ANSI status assertion remains split to avoid a control-character regex warning.

## Changelog

**[2026-06-22]**

Feedback received:

- Inline the one-off test fixture.

Changes made:

- Inlined the readable command log action fixture in `src/github.test.ts`