### PR TITLE
fix(release): avoid npm dist-tag mutation

### DIFF
--- a/gha/publish-npm.ts
+++ b/gha/publish-npm.ts
@@ -1,4 +1,4 @@
-import { action, booleanInput, job, pathInput, workflow, type ScriptExec } from "../src/index";
+import { action, booleanInput, job, pathInput, workflow } from "../src/index";
 import { checkHollywoodStateCommand, checkoutAction, setupNodeAction } from "./actions";
 
 export const publishNpmPackage = action({
@@ -12,16 +12,8 @@ export const publishNpmPackage = action({
 	outputs: {},
 	run: async ({ exec, fs, input }) => {
 		const packageJson = JSON.parse(await fs.readText(input.packageJson)) as unknown;
-		const packageName = requiredString(recordField(packageJson, "name"), "package.json name");
 		const version = requiredString(recordField(packageJson, "version"), "package.json version");
-		const prereleaseTag = prereleaseName(version);
-		const latestVersion = await npmLatestVersion(exec, packageName);
-		const tag =
-			prereleaseTag !== undefined &&
-			latestVersion !== undefined &&
-			prereleaseName(latestVersion) === undefined
-				? prereleaseTag
-				: "latest";
+		const tag = publishTagForVersion(version);
 
 		await exec("npm", [
 			"publish",
@@ -32,10 +24,6 @@ export const publishNpmPackage = action({
 			"--provenance",
 			...(input.dryRun ? ["--dry-run"] : []),
 		]);
-
-		if (prereleaseTag !== undefined && tag === "latest" && !input.dryRun) {
-			await exec("npm", ["dist-tag", "add", `${packageName}@${version}`, prereleaseTag]);
-		}
 
 		return {};
 	},
@@ -91,18 +79,6 @@ export const publishNpm = workflow({
 	},
 });
 
-const npmLatestVersion = async (exec: ScriptExec, name: string): Promise<string | undefined> => {
-	const result = await exec("npm", ["view", name, "version", "--json"], { exitPolicy: "any" });
-	if (result.exitCode !== 0) {
-		if (result.stderr.includes("E404")) {
-			return undefined;
-		}
-		throw new Error(result.stderr || `npm view ${name} failed`);
-	}
-	const version = JSON.parse(result.stdout) as unknown;
-	return requiredString(version, `npm ${name} latest version`);
-};
-
 const requiredString = (value: unknown, name: string): string => {
 	if (typeof value !== "string" || value.length === 0) {
 		throw new Error(`${name} is required`);
@@ -117,7 +93,17 @@ const recordField = (value: unknown, key: string): unknown => {
 	return (value as Record<string, unknown>)[key];
 };
 
-const prereleaseName = (value: string): string | undefined => {
-	const match = /^\d+\.\d+\.\d+-([0-9A-Za-z-]+)/.exec(value);
-	return match?.[1];
+const publishTagForVersion = (version: string): string => {
+	const match = /^\d+\.\d+\.\d+(?:-([0-9A-Za-z-]+)(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z.-]+)?$/.exec(version);
+	if (match === null) {
+		throw new Error(`package.json version must be semver: ${version}`);
+	}
+	const prereleaseTag = match[1];
+	if (prereleaseTag === undefined) {
+		return "latest";
+	}
+	if (/^\d+$/.test(prereleaseTag)) {
+		throw new Error(`npm prerelease dist-tag must not be numeric: ${prereleaseTag}`);
+	}
+	return prereleaseTag;
 };

--- a/package.json
+++ b/package.json
@@ -72,8 +72,7 @@
 		"typecheck": "tsgo --noEmit"
 	},
 	"publishConfig": {
-		"access": "public",
-		"tag": "alpha"
+		"access": "public"
 	},
 	"dependencies": {
 		"@actions/core": "3.0.1",

--- a/src/build.test.ts
+++ b/src/build.test.ts
@@ -36,6 +36,14 @@ test("published package only includes built artifacts", async () => {
 	assert.deepEqual(packageJson.files, ["dist", "README.md", "package.json"]);
 });
 
+test("package publish config does not choose the npm dist-tag", async () => {
+	const packageJson = JSON.parse(
+		await readFile(new URL("../package.json", import.meta.url), "utf8"),
+	) as { readonly publishConfig?: unknown };
+
+	assert.deepEqual(packageJson.publishConfig, { access: "public" });
+});
+
 test("release please does not rewrite generated cli source", async () => {
 	const releasePleaseConfig = JSON.parse(
 		await readFile(new URL("../release-please-config.json", import.meta.url), "utf8"),

--- a/src/publish-npm.test.ts
+++ b/src/publish-npm.test.ts
@@ -4,19 +4,13 @@ import { test } from "vitest";
 import { publishNpmPackage } from "../gha/publish-npm";
 import { runAction, type Command } from "./script";
 
-test("publish npm package advances latest while latest is prerelease", async () => {
+test("publish npm package tags stable releases as latest", async () => {
 	const commands = await runPublishAction({
-		packageJson: { name: "@dedalus-labs/hollywood", version: "0.0.1-alpha.1" },
-		latestVersion: "0.0.1-alpha.0",
+		packageJson: { name: "@dedalus-labs/hollywood", version: "0.0.1" },
 		dryRun: true,
 	});
 
 	assert.deepEqual(commands, [
-		{
-			file: "npm",
-			args: ["view", "@dedalus-labs/hollywood", "version", "--json"],
-			exitPolicy: "any",
-		},
 		{
 			file: "npm",
 			args: [
@@ -32,15 +26,14 @@ test("publish npm package advances latest while latest is prerelease", async () 
 	]);
 });
 
-test("publish npm package keeps prereleases off latest after stable", async () => {
+test("publish npm package tags prereleases by prerelease identifier", async () => {
 	const commands = await runPublishAction({
 		packageJson: { name: "@dedalus-labs/hollywood", version: "1.1.0-alpha.0" },
-		latestVersion: "1.0.0",
 		dryRun: false,
 	});
 
-	assert.equal(commands[1]?.file, "npm");
-	assert.deepEqual(commands[1]?.args, [
+	assert.equal(commands[0]?.file, "npm");
+	assert.deepEqual(commands[0]?.args, [
 		"publish",
 		"--access",
 		"public",
@@ -48,26 +41,42 @@ test("publish npm package keeps prereleases off latest after stable", async () =
 		"alpha",
 		"--provenance",
 	]);
-	assert.equal(commands.length, 2);
+	assert.equal(commands.length, 1);
 });
 
-test("publish npm package seeds prerelease tag on first prerelease publish", async () => {
+test("publish npm package rejects invalid versions before publishing", async () => {
+	await assert.rejects(
+		runPublishAction({
+			packageJson: { name: "@dedalus-labs/hollywood", version: "banana" },
+			dryRun: false,
+		}),
+		/package\.json version must be semver: banana/,
+	);
+});
+
+test("publish npm package rejects numeric prerelease tags", async () => {
+	await assert.rejects(
+		runPublishAction({
+			packageJson: { name: "@dedalus-labs/hollywood", version: "1.0.0-0" },
+			dryRun: false,
+		}),
+		/npm prerelease dist-tag must not be numeric: 0/,
+	);
+});
+
+test("publish npm package avoids dist-tag mutation", async () => {
 	const commands = await runPublishAction({
 		packageJson: { name: "@dedalus-labs/hollywood", version: "0.0.1-alpha.0" },
-		latestVersion: undefined,
 		dryRun: false,
 	});
 
 	assert.deepEqual(commands.map((command) => command.args), [
-		["view", "@dedalus-labs/hollywood", "version", "--json"],
-		["publish", "--access", "public", "--tag", "latest", "--provenance"],
-		["dist-tag", "add", "@dedalus-labs/hollywood@0.0.1-alpha.0", "alpha"],
+		["publish", "--access", "public", "--tag", "alpha", "--provenance"],
 	]);
 });
 
 const runPublishAction = async (options: {
 	packageJson: unknown;
-	latestVersion: string | undefined;
 	dryRun: boolean;
 }): Promise<Command[]> => {
 	const commands: Command[] = [];
@@ -82,12 +91,6 @@ const runPublishAction = async (options: {
 		exec: async (file, args, commandOptions) => {
 			const command = { file, args, ...commandOptions };
 			commands.push(command);
-			if (args[0] === "view") {
-				if (options.latestVersion === undefined) {
-					return { exitCode: 1, stdout: "", stderr: "npm error code E404" };
-				}
-				return { exitCode: 0, stdout: JSON.stringify(options.latestVersion), stderr: "" };
-			}
 			return { exitCode: 0, stdout: "", stderr: "" };
 		},
 		runner: { uidGid: "1000:1000" },


### PR DESCRIPTION
# Pull Request

## Summary

**What changed:**

Makes npm publish tagging deterministic from `package.json.version`: stable releases publish with `latest`, prereleases publish with their first prerelease identifier such as `alpha`, and the workflow no longer runs `npm dist-tag add` after publishing.

**Why:**

npm Trusted Publishing authenticates `npm publish` through OIDC, but does not authenticate follow-up registry mutations like `npm dist-tag add`. This keeps the release path tokenless and prevents successful publishes from reporting as failed jobs.

> [!IMPORTANT]
> Keep reviewed diffs small. If this adds more than 500 lines outside generated files or lockfiles, split it.

**Lines added, excluding generated files and lockfiles:** 52

## Test Plan

- [ ] CLA/Vouch check passes, or this PR only updates `VOUCHED.td`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test`
- [x] `npm run build`
- [ ] `npm run check`
- [x] `npm run package`

Additional targeted checks:

- [x] `npm test -- src/publish-npm.test.ts src/build.test.ts`

## Generated Output

N/A

## Repro / Showcase

The failed release workflow published `@dedalus-labs/hollywood@0.1.0-alpha.1`, then failed on the follow-up `npm dist-tag add` with `E401`. After this change, the publish action issues only one mutating npm command:

```txt
npm publish --access public --tag <latest|prerelease> --provenance
```

## Release Impact

- [ ] Runtime/library behavior changed
- [ ] CLI behavior changed
- [ ] Generated YAML changed
- [x] Package contents changed
- [ ] Documentation only
- [ ] N/A

## Compatibility

No API or Node.js compatibility change. Prerelease versions now publish only to their prerelease npm dist-tag, for example `alpha`, instead of trying to also mutate another tag after publish.

## Reviewers

- Domain: @windsornguyen
- Readability: @windsornguyen

## Notes for Reviewers

The main behavior choice is intentional: one OIDC-authenticated npm mutation per release. If we want to move extra npm tags after publish, that requires a separate authenticated npm token path, which this PR avoids.

## Changelog

**[2026-06-22]**

Feedback received:

- npm Trusted Publishing worked for `npm publish`, but the workflow failed on `npm dist-tag add` with `E401`.

Changes made:

- Removed post-publish `npm dist-tag add`.
- Derived the publish tag from the package version.
- Removed the package-level default `publishConfig.tag`.
- Added tests for stable tags, prerelease tags, invalid versions, and package publish config.
