### PR TITLE
feat:add init command for scaffolding actions/workflows

### DIFF
--- a/dist/cli.js
+++ b/dist/cli.js
@@ -6338,6 +6338,14 @@ const createCli = (io = processIo()) => {
 			...options.lima === void 0 ? {} : { lima: options.lima }
 		}, io);
 	});
+	program.command("init").description("Scaffold a minimal action or workflow source file").argument("<name>", "Name for the generated source file").option("-o, --output <dir>", "Repository root", ".").option("--source-root <dir>", "Source root directory").option("--workflow", "Scaffold a workflow instead of an action", false).action(async (name, options) => {
+		await init({
+			name,
+			output: options.output,
+			workflow: options.workflow,
+			...options.sourceRoot === void 0 ? {} : { sourceRoot: options.sourceRoot }
+		}, io);
+	});
 	return program;
 };
 const generate = async (options, io) => {
@@ -6346,6 +6354,52 @@ const generate = async (options, io) => {
 	for (const result of results) io.writeOut(`${result.status}\t${result.path}\n`);
 	if (results.length === 0) io.writeOut("unchanged	(no generated files)\n");
 };
+const init = async (options, io) => {
+	const output = resolve(options.output);
+	const path = resolve(output, await resolveSourceRoot({
+		output,
+		...options.sourceRoot === void 0 ? {} : { sourceRoot: options.sourceRoot },
+		sources: []
+	}), `${options.name}.ts`);
+	if (await pathExists(path)) throw new Error(`file already exists: ${relative(output, path).split(sep).join("/")}`);
+	await mkdir(dirname(path), { recursive: true });
+	const identifier = toIdentifier(options.name);
+	await writeFile(path, options.workflow ? workflowTemplate(identifier) : actionTemplate(identifier), "utf8");
+	io.writeOut(`created\t${relative(output, path).split(sep).join("/")}\n`);
+};
+const toIdentifier = (name) => {
+	const camel = name.split(/[^a-zA-Z0-9]+/).filter((part) => part.length > 0).map((part, index) => index === 0 ? part.charAt(0).toLowerCase() + part.slice(1) : part.charAt(0).toUpperCase() + part.slice(1)).join("");
+	return /^[a-zA-Z_]/.test(camel) ? camel : `_${camel}`;
+};
+const actionTemplate = (identifier) => `import { action, stringInput, stringOutput } from "@dedalus-labs/hollywood";
+
+export const ${identifier} = action({
+	name: "${identifier}",
+	description: "Example Hollywood action.",
+	inputs: {
+		message: stringInput({ description: "Message to transform." }),
+	},
+	outputs: {
+		result: stringOutput({ description: "Transformed message." }),
+	},
+	run: async ({ input }) => {
+		return { result: input.message.toUpperCase() };
+	},
+});
+`;
+const workflowTemplate = (identifier) => `import { job, workflow } from "@dedalus-labs/hollywood";
+
+export const ${identifier} = workflow({
+	name: "${identifier}",
+	on: { push: { branches: ["main"] } },
+	jobs: {
+		${identifier}: job({
+			"runs-on": "ubuntu-latest",
+			steps: [{ name: "Say hello", run: "echo Hello from Hollywood" }],
+		}),
+	},
+});
+`;
 const run = async (options, io) => {
 	const scriptAction = selectScriptAction(await loadHollywoodModule(options.source), options);
 	const runtime = await runRuntime(options);

--- a/src/commands.test.ts
+++ b/src/commands.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { test } from "vitest";
 
-import { buildActions, check, createCli, generate, run } from "./commands";
+import { buildActions, check, createCli, generate, init, run } from "./commands";
 
 test("generate discovers exported actions from source files", async () => {
 	const root = await mkdtemp(join(tmpdir(), "hollywood-cli-"));
@@ -746,6 +746,65 @@ const writeWorkflowSource = async (root: string): Promise<void> => {
 		"",
 	]);
 };
+
+test("init scaffolds an action source file", async () => {
+	const root = await mkdtemp(join(tmpdir(), "hollywood-cli-"));
+	const output: string[] = [];
+
+	await init(
+		{ name: "my-action", output: root, sourceRoot: "gha", workflow: false },
+		{ writeOut: (message) => output.push(message) },
+	);
+
+	assert.deepEqual(output, ["created\tgha/my-action.ts\n"]);
+	const content = await readFile(join(root, "gha/my-action.ts"), "utf8");
+	assert.match(content, /import { action, stringInput, stringOutput } from "@dedalus-labs\/hollywood";/);
+	assert.match(content, /export const myAction = action\(/);
+});
+
+test("init scaffolds a workflow source file", async () => {
+	const root = await mkdtemp(join(tmpdir(), "hollywood-cli-"));
+	const output: string[] = [];
+
+	await init(
+		{ name: "my-workflow", output: root, sourceRoot: "gha", workflow: true },
+		{ writeOut: (message) => output.push(message) },
+	);
+
+	assert.deepEqual(output, ["created\tgha/my-workflow.ts\n"]);
+	const content = await readFile(join(root, "gha/my-workflow.ts"), "utf8");
+	assert.match(content, /import { job, workflow } from "@dedalus-labs\/hollywood";/);
+	assert.match(content, /export const myWorkflow = workflow\(/);
+});
+
+test("init refuses to overwrite an existing source file", async () => {
+	const root = await mkdtemp(join(tmpdir(), "hollywood-cli-"));
+	await mkdir(join(root, "gha"), { recursive: true });
+	await writeFile(join(root, "gha/taken.ts"), "export const existing = true;\n", "utf8");
+
+	await assert.rejects(
+		init({ name: "taken", output: root, sourceRoot: "gha", workflow: false }, { writeOut: () => {} }),
+		/file already exists: gha\/taken.ts/,
+	);
+});
+
+test("createCli parses space-separated init command", async () => {
+	const root = await mkdtemp(join(tmpdir(), "hollywood-cli-"));
+	const output: string[] = [];
+
+	await createCli({ writeOut: (message) => output.push(message) }).parseAsync([
+		"node",
+		"hollywood",
+		"init",
+		"my-action",
+		"--output",
+		root,
+		"--source-root",
+		"gha",
+	]);
+
+	assert.deepEqual(output, ["created\tgha/my-action.ts\n"]);
+});
 
 const restoreEnv = (name: string, value: string | undefined): void => {
 	if (value === undefined) {

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from "node:fs";
-import { mkdtemp, readdir, readFile, rm, stat, symlink } from "node:fs/promises";
+import { mkdir, mkdtemp, readdir, readFile, rm, stat, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { basename, dirname, extname, isAbsolute, join, relative, resolve, sep } from "node:path";
 import { pathToFileURL } from "node:url";
@@ -63,6 +63,13 @@ export type BuildActionsOptions = Readonly<{
 	actionsDir: string;
 	output: string;
 	target: string;
+}>;
+
+export type InitOptions = Readonly<{
+	name: string;
+	output: string;
+	sourceRoot?: string;
+	workflow: boolean;
 }>;
 
 export type CliIo = Readonly<{
@@ -145,6 +152,25 @@ export const createCli = (io: CliIo = processIo()): Command => {
 			await run(runOptions, io);
 		});
 
+	program
+		.command("init")
+		.description("Scaffold a minimal action or workflow source file")
+		.argument("<name>", "Name for the generated source file")
+		.option("-o, --output <dir>", "Repository root", ".")
+		.option("--source-root <dir>", "Source root directory")
+		.option("--workflow", "Scaffold a workflow instead of an action", false)
+		.action(async (name, options) => {
+			await init(
+				{
+					name,
+					output: options.output,
+					workflow: options.workflow,
+					...(options.sourceRoot === undefined ? {} : { sourceRoot: options.sourceRoot }),
+				},
+				io,
+			);
+		});
+
 	return program;
 };
 
@@ -160,6 +186,66 @@ export const generate = async (options: GenerateOptions, io: CliIo): Promise<voi
 		io.writeOut("unchanged\t(no generated files)\n");
 	}
 };
+
+export const init = async (options: InitOptions, io: CliIo): Promise<void> => {
+	const output = resolve(options.output);
+	const sourceRoot = await resolveSourceRoot({
+		output,
+		...(options.sourceRoot === undefined ? {} : { sourceRoot: options.sourceRoot }),
+		sources: [],
+	});
+	const path = resolve(output, sourceRoot, `${options.name}.ts`);
+	if (await pathExists(path)) {
+		throw new Error(`file already exists: ${relative(output, path).split(sep).join("/")}`);
+	}
+	await mkdir(dirname(path), { recursive: true });
+	const identifier = toIdentifier(options.name);
+	const content = options.workflow ? workflowTemplate(identifier) : actionTemplate(identifier);
+	await writeFile(path, content, "utf8");
+	io.writeOut(`created\t${relative(output, path).split(sep).join("/")}\n`);
+};
+
+const toIdentifier = (name: string): string => {
+	const camel = name
+		.split(/[^a-zA-Z0-9]+/)
+		.filter((part) => part.length > 0)
+		.map((part, index) =>
+			index === 0 ? part.charAt(0).toLowerCase() + part.slice(1) : part.charAt(0).toUpperCase() + part.slice(1),
+		)
+		.join("");
+	return /^[a-zA-Z_]/.test(camel) ? camel : `_${camel}`;
+};
+
+const actionTemplate = (identifier: string): string => `import { action, stringInput, stringOutput } from "@dedalus-labs/hollywood";
+
+export const ${identifier} = action({
+	name: "${identifier}",
+	description: "Example Hollywood action.",
+	inputs: {
+		message: stringInput({ description: "Message to transform." }),
+	},
+	outputs: {
+		result: stringOutput({ description: "Transformed message." }),
+	},
+	run: async ({ input }) => {
+		return { result: input.message.toUpperCase() };
+	},
+});
+`;
+
+const workflowTemplate = (identifier: string): string => `import { job, workflow } from "@dedalus-labs/hollywood";
+
+export const ${identifier} = workflow({
+	name: "${identifier}",
+	on: { push: { branches: ["main"] } },
+	jobs: {
+		${identifier}: job({
+			"runs-on": "ubuntu-latest",
+			steps: [{ name: "Say hello", run: "echo Hello from Hollywood" }],
+		}),
+	},
+});
+`;
 
 export const run = async (options: RunOptions, io: CliIo): Promise<void> => {
 	const module = await loadHollywoodModule(options.source);


### PR DESCRIPTION
# Pull Request

## Summary

**What changed:**

Adds a `hollywood init <name>` CLI command that scaffolds a minimal, typed action or workflow source file (`--workflow` flag selects workflow scaffolding). Reuses the existing `resolveSourceRoot/pathExists` helpers already used by `generate`/`check, and refuses to overwrite an existing file at the target path.

**Why:**

Closes #7 . New users had to hand-copy boilerplate from the README to write their first action or workflow. `init` gives a working, typed skeleton in one command.

> [!IMPORTANT]
> Keep reviewed diffs small. If this adds more than 500 lines outside generated files or lockfiles, split it.

**Lines added, excluding generated files and lockfiles:** 147 (+147/-2 across `src/commands.ts`, `src/commands.test.ts`; `dist/cli.js`'s 54 lines are build output)
## Test Plan

- [ ] CLA/Vouch check passes, or this PR only updates `VOUCHED.td`
- [X] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test`
- [x] `npm run build`
- [x] `npm run check`
- [x] `npm run package`

## Generated Output
N/A

## Repro / Showcase

## Release Impact

- [] Runtime/library behavior changed
- [x] CLI behavior changed
- [ ] Generated YAML changed
- [ ] Package contents changed
- [ ] Documentation only
- [ ] N/A

## Compatibility
N/A

## Changelog

**[2026-07-13]**

Feedback received:

- (none yet)

Changes made:

- Initial implementation
