### PR TITLE
docs: remove unused motto styles

### DIFF
--- a/docs/assets/theme.css
+++ b/docs/assets/theme.css
@@ -178,25 +178,12 @@
   padding-bottom: 0.3em;
 }
 
-.hollywood-motto {
-  border-left: 3px solid var(--hollywood-champagne);
-  color: var(--hollywood-burgundy);
-  font-weight: 650;
-  font-style: italic;
-  margin: 1rem 0 1.2rem;
-  padding-left: 0.75rem;
-}
-
 [data-md-color-scheme="slate"] .md-typeset h1 {
   color: var(--hollywood-ivory);
 }
 
 [data-md-color-scheme="slate"] .md-typeset h2 {
   border-bottom-color: rgba(246, 198, 91, 0.24);
-}
-
-[data-md-color-scheme="slate"] .hollywood-motto {
-  color: var(--hollywood-champagne);
 }
 
 ::selection {


### PR DESCRIPTION
# Pull Request

## Summary

**What changed:**

Removed the unused `.hollywood-motto` selectors from the documentation theme.

**Why:**

No current documentation page uses this class. Removing the selectors keeps the theme aligned with rendered content.

> [!IMPORTANT]
> Keep reviewed diffs small. If this adds more than 500 lines outside generated files or lockfiles, split it.

**Lines added, excluding generated files and lockfiles:** 0.

## Test Plan

- [ ] CLA/Vouch check passes, or this PR only updates `VOUCHED.td`.
- [x] `npm run lint`.
- [x] `npm run typecheck`.
- [x] `npm test`.
- [x] `npm run build` through `npm run check`.
- [x] `npm run check`.
- [ ] `npm run package`.
- [x] `uv run --no-project --with-requirements docs/requirements.txt mkdocs build --strict -f mkdocs.yml`.

## Generated Output

N/A. This change does not affect generated workflows or actions.

## Repro / Showcase

Before this change, `git grep hollywood-motto -- README.md docs mkdocs.yml` found only the two CSS selectors. After this change, the command finds no references. The rendered site does not change because no page used the class.

## Release Impact

- [ ] Runtime/library behavior changed
- [ ] CLI behavior changed
- [ ] Generated YAML changed
- [ ] Package contents changed
- [x] Documentation only
- [ ] N/A

## Compatibility

N/A.

## Reviewers

- Domain: @tsiongk
- Readability: @annyzhou

## Notes for Reviewers

The rebased branch keeps the current container and GitHub runner documentation. The older Lima documentation changes are already superseded on `main`.

## Changelog

**[2026-08-14]**

Feedback received:

- The branch conflicted with the current documentation structure.

Changes made:

- Rebased onto current `main`.
- Kept only the unused style removal that remains applicable.
