### PR TITLE
feat(runner): define typed environment contracts

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -2,12 +2,219 @@
 import { A as ScriptFs, B as choiceInput, C as RunActionOptions, D as ScriptActionContext, E as ScriptActionCall, F as SummaryTableRow, G as stringOutput, H as pathInput, I as SummaryText, K as summaryCode, L as WorkflowInputValues, M as ScriptSummary, N as SummaryCell, O as ScriptActionServices, P as SummaryCode, R as action, S as RequiredInputName, T as ScriptAction, U as runAction, V as integerInput, W as stringInput, _ as InputDefinition, a as GitHubLogColor, b as OutputDefinition, c as ActionCallInputValues, d as ChoiceInputDefinition, f as Command, g as CommandResult, h as CommandOptions, i as GitHubInputOptions, j as ScriptLog, k as ScriptExec, l as ActionInputValues, m as CommandExitPolicy, n as GitHubExec, o as RunGitHubActionOptions, p as CommandEnvironment, q as summaryText, r as GitHubExecOptions, s as runGitHubAction, t as GitHubCore, u as ActionOutputValues, v as InputDefinitions, w as RunnerContext, x as OutputDefinitions, y as InputKind, z as booleanInput } from "./github-LHaDutAi.js";
 import { AccountName, EnvironmentAccount, EnvironmentAccounts, EnvironmentDefinition, EnvironmentDefinitions, EnvironmentName, EnvironmentRegistry, EnvironmentSelector, ResolvedEnvironment, defineEnvironmentRegistry, resolveEnvironment, selectEnvironmentName } from "./environments.js";
 import { A as runner, C as ne, D as needsResultIs, E as needsResultIn, F as valueOr, M as selectString, N as stepOutput, O as not, P as success, S as matrix, T as needsResult, _ as format, a as GitHubJobResultValue, b as hashFiles, c as always, d as contains, f as defineMatrix, g as failure, h as expr, i as GitHubJobResult, j as secret, k as or, l as and, m as eq, n as GitHubExpression, o as GitHubMatrixValues, p as envVar, r as GitHubExpressionValue, s as GitHubTypedMatrix, t as AnyGitHubTypedMatrix, u as cancelled, v as gh, w as needsOutput, x as input, y as github } from "./expressions-CNeNMhG5.js";
+import { z } from "zod";
 
 //#region src/local.d.ts
 declare const nodeFs: ScriptFs;
 declare const nodeExec: ScriptExec;
 declare const nodeLog: ScriptLog;
 declare const currentRunner: () => RunnerContext;
+//#endregion
+//#region src/runner-schema.d.ts
+declare const runnerProbeSchemaVersion: 1;
+declare const runnerEnvironmentNames: readonly ["CI", "GITHUB_ACTIONS", "ImageOS", "ImageVersion", "RUNNER_ARCH", "RUNNER_OS"];
+declare const runnerPathEnvironmentNames: readonly ["GITHUB_ENV", "GITHUB_EVENT_PATH", "GITHUB_OUTPUT", "GITHUB_PATH", "GITHUB_STEP_SUMMARY", "GITHUB_WORKSPACE", "HOME", "RUNNER_TEMP", "RUNNER_TOOL_CACHE"];
+declare const runnerToolNames: readonly ["bash", "cargo", "clang", "cmake", "curl", "docker", "gcc", "gh", "git", "go", "java", "jq", "make", "node", "npm", "podman", "python3", "ruby", "rustc", "tar", "zstd"];
+declare const runnerProbeSchema: z.ZodObject<{
+  schemaVersion: z.ZodLiteral<1>;
+  environment: z.ZodRecord<z.ZodEnum<{
+    CI: "CI";
+    GITHUB_ACTIONS: "GITHUB_ACTIONS";
+    ImageOS: "ImageOS";
+    ImageVersion: "ImageVersion";
+    RUNNER_ARCH: "RUNNER_ARCH";
+    RUNNER_OS: "RUNNER_OS";
+  }> & z.core.$partial, z.ZodString>;
+  identity: z.ZodObject<{
+    gid: z.ZodNumber;
+    groups: z.ZodArray<z.ZodString>;
+    uid: z.ZodNumber;
+  }, z.core.$strict>;
+  packages: z.ZodDiscriminatedUnion<[z.ZodObject<{
+    manager: z.ZodLiteral<"none">;
+    packages: z.ZodTuple<[], null>;
+  }, z.core.$strict>, z.ZodObject<{
+    manager: z.ZodLiteral<"dpkg">;
+    packages: z.ZodArray<z.ZodObject<{
+      name: z.ZodString;
+      version: z.ZodString;
+    }, z.core.$strict>>;
+  }, z.core.$strict>], "manager">;
+  paths: z.ZodArray<z.ZodDiscriminatedUnion<[z.ZodObject<{
+    name: z.ZodEnum<{
+      GITHUB_ENV: "GITHUB_ENV";
+      GITHUB_EVENT_PATH: "GITHUB_EVENT_PATH";
+      GITHUB_OUTPUT: "GITHUB_OUTPUT";
+      GITHUB_PATH: "GITHUB_PATH";
+      GITHUB_STEP_SUMMARY: "GITHUB_STEP_SUMMARY";
+      GITHUB_WORKSPACE: "GITHUB_WORKSPACE";
+      HOME: "HOME";
+      RUNNER_TEMP: "RUNNER_TEMP";
+      RUNNER_TOOL_CACHE: "RUNNER_TOOL_CACHE";
+    }>;
+    status: z.ZodLiteral<"absent">;
+  }, z.core.$strict>, z.ZodObject<{
+    absolute: z.ZodBoolean;
+    exists: z.ZodBoolean;
+    name: z.ZodEnum<{
+      GITHUB_ENV: "GITHUB_ENV";
+      GITHUB_EVENT_PATH: "GITHUB_EVENT_PATH";
+      GITHUB_OUTPUT: "GITHUB_OUTPUT";
+      GITHUB_PATH: "GITHUB_PATH";
+      GITHUB_STEP_SUMMARY: "GITHUB_STEP_SUMMARY";
+      GITHUB_WORKSPACE: "GITHUB_WORKSPACE";
+      HOME: "HOME";
+      RUNNER_TEMP: "RUNNER_TEMP";
+      RUNNER_TOOL_CACHE: "RUNNER_TOOL_CACHE";
+    }>;
+    status: z.ZodLiteral<"ready">;
+    value: z.ZodString;
+    writable: z.ZodBoolean;
+  }, z.core.$strict>], "status">>;
+  platform: z.ZodObject<{
+    architecture: z.ZodString;
+    capabilities: z.ZodString;
+    cgroup: z.ZodEnum<{
+      v1: "v1";
+      v2: "v2";
+    }>;
+    kernelRelease: z.ZodString;
+    kernelVersion: z.ZodString;
+    os: z.ZodObject<{
+      id: z.ZodString;
+      prettyName: z.ZodString;
+      versionId: z.ZodString;
+    }, z.core.$strict>;
+  }, z.core.$strict>;
+  tools: z.ZodArray<z.ZodDiscriminatedUnion<[z.ZodObject<{
+    name: z.ZodEnum<{
+      bash: "bash";
+      cargo: "cargo";
+      clang: "clang";
+      cmake: "cmake";
+      curl: "curl";
+      docker: "docker";
+      gcc: "gcc";
+      gh: "gh";
+      git: "git";
+      go: "go";
+      java: "java";
+      jq: "jq";
+      make: "make";
+      node: "node";
+      npm: "npm";
+      podman: "podman";
+      python3: "python3";
+      ruby: "ruby";
+      rustc: "rustc";
+      tar: "tar";
+      zstd: "zstd";
+    }>;
+    status: z.ZodLiteral<"absent">;
+  }, z.core.$strict>, z.ZodObject<{
+    name: z.ZodEnum<{
+      bash: "bash";
+      cargo: "cargo";
+      clang: "clang";
+      cmake: "cmake";
+      curl: "curl";
+      docker: "docker";
+      gcc: "gcc";
+      gh: "gh";
+      git: "git";
+      go: "go";
+      java: "java";
+      jq: "jq";
+      make: "make";
+      node: "node";
+      npm: "npm";
+      podman: "podman";
+      python3: "python3";
+      ruby: "ruby";
+      rustc: "rustc";
+      tar: "tar";
+      zstd: "zstd";
+    }>;
+    path: z.ZodString;
+    status: z.ZodLiteral<"ready">;
+    version: z.ZodString;
+  }, z.core.$strict>], "status">>;
+  toolCache: z.ZodRecord<z.ZodString, z.ZodArray<z.ZodString>>;
+}, z.core.$strict>;
+declare const runnerContractSchema: z.ZodObject<{
+  schemaVersion: z.ZodLiteral<1>;
+  environment: z.ZodRecord<z.ZodEnum<{
+    CI: "CI";
+    GITHUB_ACTIONS: "GITHUB_ACTIONS";
+    ImageOS: "ImageOS";
+    ImageVersion: "ImageVersion";
+    RUNNER_ARCH: "RUNNER_ARCH";
+    RUNNER_OS: "RUNNER_OS";
+  }> & z.core.$partial, z.ZodString>;
+  os: z.ZodObject<{
+    id: z.ZodString;
+    versionId: z.ZodString;
+  }, z.core.$strict>;
+  paths: z.ZodArray<z.ZodEnum<{
+    GITHUB_ENV: "GITHUB_ENV";
+    GITHUB_EVENT_PATH: "GITHUB_EVENT_PATH";
+    GITHUB_OUTPUT: "GITHUB_OUTPUT";
+    GITHUB_PATH: "GITHUB_PATH";
+    GITHUB_STEP_SUMMARY: "GITHUB_STEP_SUMMARY";
+    GITHUB_WORKSPACE: "GITHUB_WORKSPACE";
+    HOME: "HOME";
+    RUNNER_TEMP: "RUNNER_TEMP";
+    RUNNER_TOOL_CACHE: "RUNNER_TOOL_CACHE";
+  }>>;
+  tools: z.ZodArray<z.ZodObject<{
+    name: z.ZodEnum<{
+      bash: "bash";
+      cargo: "cargo";
+      clang: "clang";
+      cmake: "cmake";
+      curl: "curl";
+      docker: "docker";
+      gcc: "gcc";
+      gh: "gh";
+      git: "git";
+      go: "go";
+      java: "java";
+      jq: "jq";
+      make: "make";
+      node: "node";
+      npm: "npm";
+      podman: "podman";
+      python3: "python3";
+      ruby: "ruby";
+      rustc: "rustc";
+      tar: "tar";
+      zstd: "zstd";
+    }>;
+    versionPrefix: z.ZodOptional<z.ZodString>;
+  }, z.core.$strict>>;
+}, z.core.$strict>;
+type DeepReadonly<Value> = Value extends readonly unknown[] ? { readonly [Key in keyof Value]: DeepReadonly<Value[Key]> } : Value extends object ? { readonly [Key in keyof Value]: DeepReadonly<Value[Key]> } : Value;
+type RunnerEnvironmentName = (typeof runnerEnvironmentNames)[number];
+type RunnerPathEnvironmentName = (typeof runnerPathEnvironmentNames)[number];
+type RunnerToolName = (typeof runnerToolNames)[number];
+type RunnerContract = DeepReadonly<z.infer<typeof runnerContractSchema>>;
+type RunnerProbe = DeepReadonly<z.infer<typeof runnerProbeSchema>>;
+type RunnerPackageProbe = RunnerProbe["packages"];
+type RunnerPathProbe = RunnerProbe["paths"][number];
+type RunnerToolProbe = RunnerProbe["tools"][number];
+type RunnerDifference = Readonly<{
+  category: "contract" | "inventory" | "provider";
+  actual?: unknown;
+  expected?: unknown;
+  path: string;
+}>;
+//#endregion
+//#region src/runner-contract.d.ts
+declare const defineRunnerContract: (contract: RunnerContract) => RunnerContract;
+declare const verifyRunner: (contract: RunnerContract, probe: RunnerProbe) => readonly RunnerDifference[];
+declare const compareRunnerProbes: (expected: RunnerProbe, actual: RunnerProbe) => readonly RunnerDifference[];
+declare const parseRunnerContract: (contents: string) => RunnerContract;
+declare const parseRunnerProbe: (contents: string) => RunnerProbe;
 //#endregion
 //#region src/container.d.ts
 type ContainerProvider = "container" | "docker" | "podman";
@@ -319,4 +526,4 @@ declare const validateActionMetadataContent: (file: GitHubYamlFile) => GitHubYam
 declare const assertValidWorkflowContent: (file: GitHubYamlFile) => void;
 declare const assertValidActionMetadataContent: (file: GitHubYamlFile) => void;
 //#endregion
-export { type AccountName, type ActionCallInputValues, type ActionInputValues, type ActionOutputValues, type ChoiceInputDefinition, type Command, type CommandEnvironment, type CommandExitPolicy, type CommandOptions, type CommandResult, type ContainerOptions, type ContainerProvider, ContainerProviderUnavailableError, type ContainerServices, type EnvironmentAccount, type EnvironmentAccounts, type EnvironmentDefinition, type EnvironmentDefinitions, type EnvironmentName, type EnvironmentRegistry, type EnvironmentSelector, type GeneratedFile, GeneratedFilePathCollisionError, type GeneratedFileWriteResult, type GeneratedFileWriteStatus, type GitHubActionEntrypointFile, type GitHubActionFile, type GitHubActionInputMetadata, type GitHubActionMetadata, type GitHubActionOutputMetadata, type GitHubConcurrency, type GitHubCore, type GitHubEnvironmentVariables, type GitHubExec, type GitHubExecOptions, type GitHubExpression, type GitHubExpressionString, type GitHubExpressionValue, type GitHubInputOptions, type GitHubJobOutputs, GitHubJobResult, type GitHubJobResultValue, type GitHubLocalAction, type GitHubLocalActionStepOptions, type GitHubLogColor, type GitHubMatrix, type GitHubMatrixObject, type GitHubMatrixValue, type GitHubMatrixValues, type GitHubNeeds, type GitHubPermission, type GitHubPermissions, type GitHubReusableWorkflowJob, type GitHubReusableWorkflowSecrets, type GitHubRunStep, type GitHubService, type GitHubServices, type GitHubStepWorkflowJob, type GitHubStrategy, type GitHubTypedMatrix, type GitHubUsesStep, type GitHubUsesStepOptions, type GitHubWithValues, type GitHubWorkflow, type GitHubWorkflowCallWithValues, type GitHubWorkflowFile, type GitHubWorkflowJob, type GitHubWorkflowOptions, type GitHubWorkflowStep, type GitHubYamlFile, type GitHubYamlValidation, type GitHubYamlValidationError, type InputDefinition, type InputDefinitions, type InputKind, InvalidWorkflowFilenameError, type OutputDefinition, type OutputDefinitions, type RenderedGeneratedFile, type ResolvedEnvironment, type RunActionOptions, type RunGitHubActionOptions, type RunnerContext, type ScriptAction, type ScriptActionCall, type ScriptActionContext, type ScriptActionServices, type ScriptExec, type ScriptFs, type ScriptLog, type ScriptSummary, type SummaryCell, type SummaryCode, type SummaryTableRow, type SummaryText, type WorkflowInputValues, type WriteGeneratedFilesOptions, action, always, and, assertValidActionMetadataContent, assertValidWorkflowContent, booleanInput, cancelled, choiceInput, contains, currentRunner, defineEnvironmentRegistry, defineMatrix, envVar, eq, expr, failure, format, generateActionEntrypointFile, generateActionFile, generateActionFiles, generateActionMetadata, generateUsesStep, generateWorkflowFile, gh, github, githubActionsRunnerImage, hashFiles, input, integerInput, job, localAction, matrix, ne, needsOutput, needsResult, needsResultIn, needsResultIs, nodeExec, nodeFs, nodeLog, not, or, pathInput, renderActionFile, renderGeneratedFile, renderWorkflowFile, resolveEnvironment, runAction, runGitHubAction, runner, secret, selectEnvironmentName, selectString, stepOutput, stringInput, stringOutput, success, summaryCode, summaryText, uses, validateActionMetadataContent, validateWorkflowContent, valueOr, withContainer, withLocalContainer, workflow, writeGeneratedFiles };
+export { type AccountName, type ActionCallInputValues, type ActionInputValues, type ActionOutputValues, type ChoiceInputDefinition, type Command, type CommandEnvironment, type CommandExitPolicy, type CommandOptions, type CommandResult, type ContainerOptions, type ContainerProvider, ContainerProviderUnavailableError, type ContainerServices, type EnvironmentAccount, type EnvironmentAccounts, type EnvironmentDefinition, type EnvironmentDefinitions, type EnvironmentName, type EnvironmentRegistry, type EnvironmentSelector, type GeneratedFile, GeneratedFilePathCollisionError, type GeneratedFileWriteResult, type GeneratedFileWriteStatus, type GitHubActionEntrypointFile, type GitHubActionFile, type GitHubActionInputMetadata, type GitHubActionMetadata, type GitHubActionOutputMetadata, type GitHubConcurrency, type GitHubCore, type GitHubEnvironmentVariables, type GitHubExec, type GitHubExecOptions, type GitHubExpression, type GitHubExpressionString, type GitHubExpressionValue, type GitHubInputOptions, type GitHubJobOutputs, GitHubJobResult, type GitHubJobResultValue, type GitHubLocalAction, type GitHubLocalActionStepOptions, type GitHubLogColor, type GitHubMatrix, type GitHubMatrixObject, type GitHubMatrixValue, type GitHubMatrixValues, type GitHubNeeds, type GitHubPermission, type GitHubPermissions, type GitHubReusableWorkflowJob, type GitHubReusableWorkflowSecrets, type GitHubRunStep, type GitHubService, type GitHubServices, type GitHubStepWorkflowJob, type GitHubStrategy, type GitHubTypedMatrix, type GitHubUsesStep, type GitHubUsesStepOptions, type GitHubWithValues, type GitHubWorkflow, type GitHubWorkflowCallWithValues, type GitHubWorkflowFile, type GitHubWorkflowJob, type GitHubWorkflowOptions, type GitHubWorkflowStep, type GitHubYamlFile, type GitHubYamlValidation, type GitHubYamlValidationError, type InputDefinition, type InputDefinitions, type InputKind, InvalidWorkflowFilenameError, type OutputDefinition, type OutputDefinitions, type RenderedGeneratedFile, type ResolvedEnvironment, type RunActionOptions, type RunGitHubActionOptions, type RunnerContext, type RunnerContract, type RunnerDifference, type RunnerEnvironmentName, type RunnerPackageProbe, type RunnerPathEnvironmentName, type RunnerPathProbe, type RunnerProbe, type RunnerToolName, type RunnerToolProbe, type ScriptAction, type ScriptActionCall, type ScriptActionContext, type ScriptActionServices, type ScriptExec, type ScriptFs, type ScriptLog, type ScriptSummary, type SummaryCell, type SummaryCode, type SummaryTableRow, type SummaryText, type WorkflowInputValues, type WriteGeneratedFilesOptions, action, always, and, assertValidActionMetadataContent, assertValidWorkflowContent, booleanInput, cancelled, choiceInput, compareRunnerProbes, contains, currentRunner, defineEnvironmentRegistry, defineMatrix, defineRunnerContract, envVar, eq, expr, failure, format, generateActionEntrypointFile, generateActionFile, generateActionFiles, generateActionMetadata, generateUsesStep, generateWorkflowFile, gh, github, githubActionsRunnerImage, hashFiles, input, integerInput, job, localAction, matrix, ne, needsOutput, needsResult, needsResultIn, needsResultIs, nodeExec, nodeFs, nodeLog, not, or, parseRunnerContract, parseRunnerProbe, pathInput, renderActionFile, renderGeneratedFile, renderWorkflowFile, resolveEnvironment, runAction, runGitHubAction, runner, runnerProbeSchemaVersion, secret, selectEnvironmentName, selectString, stepOutput, stringInput, stringOutput, success, summaryCode, summaryText, uses, validateActionMetadataContent, validateWorkflowContent, valueOr, verifyRunner, withContainer, withLocalContainer, workflow, writeGeneratedFiles };

--- a/dist/index.js
+++ b/dist/index.js
@@ -3,6 +3,7 @@ import { a as integerInput, c as stringInput, d as summaryText, f as toGitHubNam
 import { defineEnvironmentRegistry, resolveEnvironment, selectEnvironmentName } from "./environments.js";
 import { A as success, C as needsResultIs, D as secret, E as runner, O as selectString, S as needsResultIn, T as or, _ as isGitHubTypedMatrix, a as contains, b as needsOutput, c as eq, d as format, f as gh, g as input, h as hashFiles, i as cancelled, j as valueOr, k as stepOutput, l as expr, m as githubTypedMatrixValues, n as always, o as defineMatrix, p as github, r as and, s as envVar, t as GitHubJobResult, u as failure, v as matrix, w as not, x as needsResult, y as ne } from "./expressions-BPTcb6xM.js";
 import { chmod, copyFile, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { z } from "zod";
 import { randomUUID } from "node:crypto";
 import { tmpdir } from "node:os";
 import { dirname, isAbsolute, join, posix, relative, resolve, sep } from "node:path";
@@ -18,6 +19,222 @@ import { TemplateSchema } from "@actions/workflow-parser/templates/schema/index"
 import { NoOperationTraceWriter } from "@actions/workflow-parser/templates/trace-writer";
 import { WORKFLOW_ROOT } from "@actions/workflow-parser/workflows/workflow-constants";
 import { YamlObjectReader } from "@actions/workflow-parser/workflows/yaml-object-reader";
+//#region src/runner-schema.ts
+const runnerProbeSchemaVersion = 1;
+const runnerEnvironmentNames = [
+	"CI",
+	"GITHUB_ACTIONS",
+	"ImageOS",
+	"ImageVersion",
+	"RUNNER_ARCH",
+	"RUNNER_OS"
+];
+const runnerPathEnvironmentNames = [
+	"GITHUB_ENV",
+	"GITHUB_EVENT_PATH",
+	"GITHUB_OUTPUT",
+	"GITHUB_PATH",
+	"GITHUB_STEP_SUMMARY",
+	"GITHUB_WORKSPACE",
+	"HOME",
+	"RUNNER_TEMP",
+	"RUNNER_TOOL_CACHE"
+];
+const runnerToolNames = [
+	"bash",
+	"cargo",
+	"clang",
+	"cmake",
+	"curl",
+	"docker",
+	"gcc",
+	"gh",
+	"git",
+	"go",
+	"java",
+	"jq",
+	"make",
+	"node",
+	"npm",
+	"podman",
+	"python3",
+	"ruby",
+	"rustc",
+	"tar",
+	"zstd"
+];
+const text = z.string().min(1);
+const environment = z.partialRecord(z.enum(runnerEnvironmentNames), z.string());
+const pathName = z.enum(runnerPathEnvironmentNames);
+const toolName = z.enum(runnerToolNames);
+const pathProbe = z.discriminatedUnion("status", [z.strictObject({
+	name: pathName,
+	status: z.literal("absent")
+}), z.strictObject({
+	absolute: z.boolean(),
+	exists: z.boolean(),
+	name: pathName,
+	status: z.literal("ready"),
+	value: text,
+	writable: z.boolean()
+})]);
+const toolProbe = z.discriminatedUnion("status", [z.strictObject({
+	name: toolName,
+	status: z.literal("absent")
+}), z.strictObject({
+	name: toolName,
+	path: text,
+	status: z.literal("ready"),
+	version: text
+})]);
+const packageRecord = z.strictObject({
+	name: text,
+	version: text
+});
+const packageProbe = z.discriminatedUnion("manager", [z.strictObject({
+	manager: z.literal("none"),
+	packages: z.tuple([])
+}), z.strictObject({
+	manager: z.literal("dpkg"),
+	packages: z.array(packageRecord)
+})]);
+const runnerProbeSchema = z.strictObject({
+	schemaVersion: z.literal(1),
+	environment,
+	identity: z.strictObject({
+		gid: z.number().int().nonnegative(),
+		groups: z.array(text),
+		uid: z.number().int().nonnegative()
+	}),
+	packages: packageProbe,
+	paths: z.array(pathProbe),
+	platform: z.strictObject({
+		architecture: text,
+		capabilities: text,
+		cgroup: z.enum(["v1", "v2"]),
+		kernelRelease: text,
+		kernelVersion: text,
+		os: z.strictObject({
+			id: text,
+			prettyName: text,
+			versionId: text
+		})
+	}),
+	tools: z.array(toolProbe),
+	toolCache: z.record(z.string(), z.array(text))
+});
+const runnerContractSchema = z.strictObject({
+	schemaVersion: z.literal(1),
+	environment,
+	os: z.strictObject({
+		id: text,
+		versionId: text
+	}),
+	paths: z.array(pathName),
+	tools: z.array(z.strictObject({
+		name: toolName,
+		versionPrefix: z.string().min(1).optional()
+	}))
+});
+//#endregion
+//#region src/runner-contract.ts
+const defineRunnerContract = (contract) => {
+	assertUnique(contract.paths, "runner contract paths");
+	assertUniqueNames(contract.tools, "runner contract tools");
+	return contract;
+};
+const verifyRunner = (contract, probe) => {
+	const differences = [];
+	difference(differences, "schemaVersion", contract.schemaVersion, probe.schemaVersion);
+	difference(differences, "platform.os.id", contract.os.id, probe.platform.os.id);
+	difference(differences, "platform.os.versionId", contract.os.versionId, probe.platform.os.versionId);
+	for (const [name, expected] of Object.entries(contract.environment)) difference(differences, `environment.${name}`, expected, probe.environment[name]);
+	for (const name of contract.paths) {
+		const path = probe.paths.find((candidate) => candidate.name === name);
+		difference(differences, `paths.${name}.status`, "ready", path?.status);
+		if (path?.status === "ready") {
+			difference(differences, `paths.${name}.absolute`, true, path.absolute);
+			difference(differences, `paths.${name}.exists`, true, path.exists);
+			difference(differences, `paths.${name}.writable`, true, path.writable);
+		}
+	}
+	for (const expected of contract.tools) {
+		const tool = probe.tools.find((candidate) => candidate.name === expected.name);
+		difference(differences, `tools.${expected.name}.status`, "ready", tool?.status);
+		if (tool?.status === "ready" && expected.versionPrefix !== void 0 && !tool.version.startsWith(expected.versionPrefix)) differences.push({
+			category: "contract",
+			actual: tool.version,
+			expected: `${expected.versionPrefix}*`,
+			path: `tools.${expected.name}.version`
+		});
+	}
+	return differences;
+};
+const compareRunnerProbes = (expected, actual) => compareValues("", comparisonShape(expected), comparisonShape(actual));
+const parseRunnerContract = (contents) => defineRunnerContract(parseJson(runnerContractSchema, contents, "runner contract"));
+const parseRunnerProbe = (contents) => {
+	const probe = parseJson(runnerProbeSchema, contents, "runner probe");
+	assertUniqueNames(probe.packages.packages, "runner probe packages");
+	assertUniqueNames(probe.paths, "runner probe paths");
+	assertUniqueNames(probe.tools, "runner probe tools");
+	return probe;
+};
+const parseJson = (schema, contents, name) => {
+	let value;
+	try {
+		value = JSON.parse(contents);
+	} catch (error) {
+		throw new Error(`${name} is not valid JSON`, { cause: error });
+	}
+	const result = schema.safeParse(value);
+	if (result.success) return result.data;
+	const issue = result.error.issues[0];
+	const path = issue === void 0 || issue.path.length === 0 ? "" : ` at ${issue.path.join(".")}`;
+	throw new Error(`${name} is invalid${path}: ${issue?.message ?? "unknown schema error"}`, { cause: result.error });
+};
+const comparisonShape = (probe) => ({
+	...probe,
+	packages: {
+		...probe.packages,
+		packages: Object.fromEntries(probe.packages.packages.map((entry) => [entry.name, entry]))
+	},
+	paths: Object.fromEntries(probe.paths.map((entry) => [entry.name, entry])),
+	tools: Object.fromEntries(probe.tools.map((entry) => [entry.name, entry]))
+});
+const compareValues = (path, expected, actual) => {
+	if (Object.is(expected, actual)) return [];
+	if (Array.isArray(expected) && Array.isArray(actual)) {
+		const length = Math.max(expected.length, actual.length);
+		return Array.from({ length }, (_, index) => compareValues(joinPath(path, String(index)), expected[index], actual[index])).flat();
+	}
+	if (isRecord(expected) && isRecord(actual)) return [...new Set([...Object.keys(expected), ...Object.keys(actual)])].sort().flatMap((key) => compareValues(joinPath(path, key), expected[key], actual[key]));
+	return [{
+		category: differenceCategory(path),
+		actual,
+		expected,
+		path
+	}];
+};
+const differenceCategory = (path) => {
+	if (/^(identity|platform\.(architecture|capabilities|cgroup|kernel))/.test(path)) return "provider";
+	if (/^(packages|toolCache)/.test(path) || /^tools\.[^.]+\.(path|version)$/.test(path) || path === "environment.ImageVersion" || /^paths\.[^.]+\.value$/.test(path)) return "inventory";
+	return "contract";
+};
+const difference = (differences, path, expected, actual) => {
+	if (!Object.is(expected, actual)) differences.push({
+		category: "contract",
+		actual,
+		expected,
+		path
+	});
+};
+const assertUniqueNames = (entries, name) => assertUnique(entries.map(({ name }) => name), `${name} names`);
+const assertUnique = (values, name) => {
+	if (new Set(values).size !== values.length) throw new Error(`${name} must be unique`);
+};
+const joinPath = (prefix, suffix) => prefix === "" ? suffix : `${prefix}.${suffix}`;
+const isRecord = (value) => value !== null && typeof value === "object" && !Array.isArray(value);
+//#endregion
 //#region src/container.ts
 var ContainerProviderUnavailableError = class extends Error {
 	binary;
@@ -559,4 +776,4 @@ const resolveOutputPath = (outputDir, path) => {
 	return outputPath;
 };
 //#endregion
-export { ContainerProviderUnavailableError, GeneratedFilePathCollisionError, GitHubJobResult, InvalidWorkflowFilenameError, action, always, and, assertValidActionMetadataContent, assertValidWorkflowContent, booleanInput, cancelled, choiceInput, contains, currentRunner, defineEnvironmentRegistry, defineMatrix, envVar, eq, expr, failure, format, generateActionEntrypointFile, generateActionFile, generateActionFiles, generateActionMetadata, generateUsesStep, generateWorkflowFile, gh, github, githubActionsRunnerImage, hashFiles, input, integerInput, job, localAction, matrix, ne, needsOutput, needsResult, needsResultIn, needsResultIs, nodeExec, nodeFs, nodeLog, not, or, pathInput, renderActionFile, renderGeneratedFile, renderWorkflowFile, resolveEnvironment, runAction, runGitHubAction, runner, secret, selectEnvironmentName, selectString, stepOutput, stringInput, stringOutput, success, summaryCode, summaryText, uses, validateActionMetadataContent, validateWorkflowContent, valueOr, withContainer, withLocalContainer, workflow, writeGeneratedFiles };
+export { ContainerProviderUnavailableError, GeneratedFilePathCollisionError, GitHubJobResult, InvalidWorkflowFilenameError, action, always, and, assertValidActionMetadataContent, assertValidWorkflowContent, booleanInput, cancelled, choiceInput, compareRunnerProbes, contains, currentRunner, defineEnvironmentRegistry, defineMatrix, defineRunnerContract, envVar, eq, expr, failure, format, generateActionEntrypointFile, generateActionFile, generateActionFiles, generateActionMetadata, generateUsesStep, generateWorkflowFile, gh, github, githubActionsRunnerImage, hashFiles, input, integerInput, job, localAction, matrix, ne, needsOutput, needsResult, needsResultIn, needsResultIs, nodeExec, nodeFs, nodeLog, not, or, parseRunnerContract, parseRunnerProbe, pathInput, renderActionFile, renderGeneratedFile, renderWorkflowFile, resolveEnvironment, runAction, runGitHubAction, runner, runnerProbeSchemaVersion, secret, selectEnvironmentName, selectString, stepOutput, stringInput, stringOutput, success, summaryCode, summaryText, uses, validateActionMetadataContent, validateWorkflowContent, valueOr, verifyRunner, withContainer, withLocalContainer, workflow, writeGeneratedFiles };

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
 				"@actions/expressions": "0.3.57",
 				"@actions/workflow-parser": "0.3.55",
 				"esbuild": "0.28.1",
-				"yaml": "2.8.4"
+				"yaml": "2.8.4",
+				"zod": "4.4.3"
 			},
 			"bin": {
 				"hollywood": "dist/cli.js"
@@ -3348,6 +3349,15 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/eemeli"
+			}
+		},
+		"node_modules/zod": {
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+			"integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/colinhacks"
 			}
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -79,7 +79,8 @@
 		"@actions/expressions": "0.3.57",
 		"@actions/workflow-parser": "0.3.55",
 		"esbuild": "0.28.1",
-		"yaml": "2.8.4"
+		"yaml": "2.8.4",
+		"zod": "4.4.3"
 	},
 	"devDependencies": {
 		"@commander-js/extra-typings": "14.0.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,6 +44,27 @@ export {
 
 export { currentRunner, nodeExec, nodeFs, nodeLog } from "./local";
 export type {
+	RunnerContract,
+	RunnerDifference,
+	RunnerPackageProbe,
+	RunnerPathProbe,
+	RunnerProbe,
+	RunnerToolProbe,
+} from "./runner-contract";
+export {
+	compareRunnerProbes,
+	defineRunnerContract,
+	parseRunnerContract,
+	parseRunnerProbe,
+	verifyRunner,
+} from "./runner-contract";
+export type {
+	RunnerEnvironmentName,
+	RunnerPathEnvironmentName,
+	RunnerToolName,
+} from "./runner-schema";
+export { runnerProbeSchemaVersion } from "./runner-schema";
+export type {
 	ContainerOptions,
 	ContainerProvider,
 	ContainerServices,

--- a/src/runner-contract.test.ts
+++ b/src/runner-contract.test.ts
@@ -1,0 +1,93 @@
+import assert from "node:assert/strict";
+import { test } from "vitest";
+
+import {
+	compareRunnerProbes,
+	defineRunnerContract,
+	parseRunnerContract,
+	parseRunnerProbe,
+	verifyRunner,
+	type RunnerContract,
+	type RunnerProbe,
+} from "./runner-contract";
+
+const contract: RunnerContract = {
+	schemaVersion: 1,
+	environment: { CI: "true", RUNNER_OS: "Linux" },
+	os: { id: "ubuntu", versionId: "24.04" },
+	paths: ["GITHUB_WORKSPACE"],
+	tools: [{ name: "node", versionPrefix: "v24." }],
+};
+
+const probe: RunnerProbe = {
+	schemaVersion: 1,
+	environment: { CI: "true", RUNNER_OS: "Linux" },
+	identity: { gid: 1001, groups: ["runner"], uid: 1001 },
+	packages: { manager: "dpkg", packages: [{ name: "bash", version: "5.2" }] },
+	paths: [{
+		absolute: true,
+		exists: true,
+		name: "GITHUB_WORKSPACE",
+		status: "ready",
+		value: "/github/workspace",
+		writable: true,
+	}],
+	platform: {
+		architecture: "arm64",
+		capabilities: "000001ffffffffff",
+		cgroup: "v2",
+		kernelRelease: "6.16.9",
+		kernelVersion: "Linux",
+		os: { id: "ubuntu", prettyName: "Ubuntu 24.04 LTS", versionId: "24.04" },
+	},
+	tools: [{ name: "node", path: "/usr/bin/node", status: "ready", version: "v24.11.0" }],
+	toolCache: { node: ["24.11.0"] },
+};
+
+test("runner contract verifies semantic requirements", () => {
+	assert.deepEqual(verifyRunner(defineRunnerContract(contract), probe), []);
+	assert.deepEqual(
+		verifyRunner(contract, { ...probe, tools: [{ name: "node", status: "absent" }] }),
+		[{
+			category: "contract",
+			actual: "absent",
+			expected: "ready",
+			path: "tools.node.status",
+		}],
+	);
+});
+
+test("runner comparison classifies drift by ownership", () => {
+	const actual = {
+		...probe,
+		environment: { ...probe.environment, CI: "false" },
+		packages: { manager: "dpkg", packages: [{ name: "bash", version: "5.3" }] },
+		platform: { ...probe.platform, kernelRelease: "different" },
+	} satisfies RunnerProbe;
+
+	assert.deepEqual(
+		compareRunnerProbes(probe, actual).map(({ category, path }) => ({ category, path })),
+		[
+			{ category: "contract", path: "environment.CI" },
+			{ category: "inventory", path: "packages.packages.bash.version" },
+			{ category: "provider", path: "platform.kernelRelease" },
+		],
+	);
+});
+
+test("runner schemas reject malformed and undeclared state", () => {
+	assert.deepEqual(parseRunnerContract(JSON.stringify(contract)), contract);
+	assert.deepEqual(parseRunnerProbe(JSON.stringify(probe)), probe);
+	assert.throws(
+		() => parseRunnerContract(JSON.stringify({ ...contract, secret: "nope" })),
+		/runner contract is invalid: Unrecognized key/,
+	);
+	assert.throws(
+		() => parseRunnerProbe(JSON.stringify({ ...probe, identity: { ...probe.identity, secret: "nope" } })),
+		/runner probe is invalid at identity: Unrecognized key/,
+	);
+	assert.throws(
+		() => parseRunnerProbe(JSON.stringify({ ...probe, tools: [probe.tools[0], probe.tools[0]] })),
+		/runner probe tools names must be unique/,
+	);
+});

--- a/src/runner-contract.ts
+++ b/src/runner-contract.ts
@@ -1,0 +1,187 @@
+import { z } from "zod";
+
+import {
+	runnerContractSchema,
+	runnerProbeSchema,
+	type RunnerContract,
+	type RunnerDifference,
+	type RunnerEnvironmentName,
+	type RunnerProbe,
+} from "./runner-schema";
+
+export type {
+	RunnerContract,
+	RunnerDifference,
+	RunnerPackageProbe,
+	RunnerPathProbe,
+	RunnerProbe,
+	RunnerToolProbe,
+} from "./runner-schema";
+
+export const defineRunnerContract = (contract: RunnerContract): RunnerContract => {
+	assertUnique(contract.paths, "runner contract paths");
+	assertUniqueNames(contract.tools, "runner contract tools");
+	return contract;
+};
+
+export const verifyRunner = (
+	contract: RunnerContract,
+	probe: RunnerProbe,
+): readonly RunnerDifference[] => {
+	const differences: RunnerDifference[] = [];
+	difference(differences, "schemaVersion", contract.schemaVersion, probe.schemaVersion);
+	difference(differences, "platform.os.id", contract.os.id, probe.platform.os.id);
+	difference(
+		differences,
+		"platform.os.versionId",
+		contract.os.versionId,
+		probe.platform.os.versionId,
+	);
+	for (const [name, expected] of Object.entries(contract.environment)) {
+		difference(
+			differences,
+			`environment.${name}`,
+			expected,
+			probe.environment[name as RunnerEnvironmentName],
+		);
+	}
+	for (const name of contract.paths) {
+		const path = probe.paths.find((candidate) => candidate.name === name);
+		difference(differences, `paths.${name}.status`, "ready", path?.status);
+		if (path?.status === "ready") {
+			difference(differences, `paths.${name}.absolute`, true, path.absolute);
+			difference(differences, `paths.${name}.exists`, true, path.exists);
+			difference(differences, `paths.${name}.writable`, true, path.writable);
+		}
+	}
+	for (const expected of contract.tools) {
+		const tool = probe.tools.find((candidate) => candidate.name === expected.name);
+		difference(differences, `tools.${expected.name}.status`, "ready", tool?.status);
+		if (
+			tool?.status === "ready" &&
+			expected.versionPrefix !== undefined &&
+			!tool.version.startsWith(expected.versionPrefix)
+		) {
+			differences.push({
+				category: "contract",
+				actual: tool.version,
+				expected: `${expected.versionPrefix}*`,
+				path: `tools.${expected.name}.version`,
+			});
+		}
+	}
+	return differences;
+};
+
+export const compareRunnerProbes = (
+	expected: RunnerProbe,
+	actual: RunnerProbe,
+): readonly RunnerDifference[] =>
+	compareValues("", comparisonShape(expected), comparisonShape(actual));
+
+export const parseRunnerContract = (contents: string): RunnerContract =>
+	defineRunnerContract(parseJson(runnerContractSchema, contents, "runner contract"));
+
+export const parseRunnerProbe = (contents: string): RunnerProbe => {
+	const probe = parseJson(runnerProbeSchema, contents, "runner probe");
+	assertUniqueNames(probe.packages.packages, "runner probe packages");
+	assertUniqueNames(probe.paths, "runner probe paths");
+	assertUniqueNames(probe.tools, "runner probe tools");
+	return probe;
+};
+
+const parseJson = <Schema extends z.ZodType>(
+	schema: Schema,
+	contents: string,
+	name: string,
+): z.infer<Schema> => {
+	let value: unknown;
+	try {
+		value = JSON.parse(contents);
+	} catch (error) {
+		throw new Error(`${name} is not valid JSON`, { cause: error });
+	}
+	const result = schema.safeParse(value);
+	if (result.success) {
+		return result.data;
+	}
+	const issue = result.error.issues[0];
+	const path = issue === undefined || issue.path.length === 0 ? "" : ` at ${issue.path.join(".")}`;
+	throw new Error(`${name} is invalid${path}: ${issue?.message ?? "unknown schema error"}`, {
+		cause: result.error,
+	});
+};
+
+const comparisonShape = (probe: RunnerProbe): unknown => ({
+	...probe,
+	packages: {
+		...probe.packages,
+		packages: Object.fromEntries(
+			probe.packages.packages.map((entry) => [entry.name, entry]),
+		),
+	},
+	paths: Object.fromEntries(probe.paths.map((entry) => [entry.name, entry])),
+	tools: Object.fromEntries(probe.tools.map((entry) => [entry.name, entry])),
+});
+
+const compareValues = (path: string, expected: unknown, actual: unknown): RunnerDifference[] => {
+	if (Object.is(expected, actual)) {
+		return [];
+	}
+	if (Array.isArray(expected) && Array.isArray(actual)) {
+		const length = Math.max(expected.length, actual.length);
+		return Array.from({ length }, (_, index) =>
+			compareValues(joinPath(path, String(index)), expected[index], actual[index]),
+		).flat();
+	}
+	if (isRecord(expected) && isRecord(actual)) {
+		const keys = [...new Set([...Object.keys(expected), ...Object.keys(actual)])].sort();
+		return keys.flatMap((key) =>
+			compareValues(joinPath(path, key), expected[key], actual[key]),
+		);
+	}
+	return [{ category: differenceCategory(path), actual, expected, path }];
+};
+
+const differenceCategory = (path: string): RunnerDifference["category"] => {
+	if (/^(identity|platform\.(architecture|capabilities|cgroup|kernel))/.test(path)) {
+		return "provider";
+	}
+	if (
+		/^(packages|toolCache)/.test(path) ||
+		/^tools\.[^.]+\.(path|version)$/.test(path) ||
+		path === "environment.ImageVersion" ||
+		/^paths\.[^.]+\.value$/.test(path)
+	) {
+		return "inventory";
+	}
+	return "contract";
+};
+
+const difference = (
+	differences: RunnerDifference[],
+	path: string,
+	expected: unknown,
+	actual: unknown,
+): void => {
+	if (!Object.is(expected, actual)) {
+		differences.push({ category: "contract", actual, expected, path });
+	}
+};
+
+const assertUniqueNames = (
+	entries: readonly Readonly<{ name: string }>[],
+	name: string,
+): void => assertUnique(entries.map(({ name }) => name), `${name} names`);
+
+const assertUnique = (values: readonly string[], name: string): void => {
+	if (new Set(values).size !== values.length) {
+		throw new Error(`${name} must be unique`);
+	}
+};
+
+const joinPath = (prefix: string, suffix: string): string =>
+	prefix === "" ? suffix : `${prefix}.${suffix}`;
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+	value !== null && typeof value === "object" && !Array.isArray(value);

--- a/src/runner-schema.ts
+++ b/src/runner-schema.ts
@@ -1,0 +1,138 @@
+import { z } from "zod";
+
+export const runnerProbeSchemaVersion = 1 as const;
+
+export const runnerEnvironmentNames = [
+	"CI",
+	"GITHUB_ACTIONS",
+	"ImageOS",
+	"ImageVersion",
+	"RUNNER_ARCH",
+	"RUNNER_OS",
+] as const;
+
+export const runnerPathEnvironmentNames = [
+	"GITHUB_ENV",
+	"GITHUB_EVENT_PATH",
+	"GITHUB_OUTPUT",
+	"GITHUB_PATH",
+	"GITHUB_STEP_SUMMARY",
+	"GITHUB_WORKSPACE",
+	"HOME",
+	"RUNNER_TEMP",
+	"RUNNER_TOOL_CACHE",
+] as const;
+
+export const runnerToolNames = [
+	"bash",
+	"cargo",
+	"clang",
+	"cmake",
+	"curl",
+	"docker",
+	"gcc",
+	"gh",
+	"git",
+	"go",
+	"java",
+	"jq",
+	"make",
+	"node",
+	"npm",
+	"podman",
+	"python3",
+	"ruby",
+	"rustc",
+	"tar",
+	"zstd",
+] as const;
+
+const text = z.string().min(1);
+const environment = z.partialRecord(z.enum(runnerEnvironmentNames), z.string());
+const pathName = z.enum(runnerPathEnvironmentNames);
+const toolName = z.enum(runnerToolNames);
+
+const pathProbe = z.discriminatedUnion("status", [
+	z.strictObject({ name: pathName, status: z.literal("absent") }),
+	z.strictObject({
+		absolute: z.boolean(),
+		exists: z.boolean(),
+		name: pathName,
+		status: z.literal("ready"),
+		value: text,
+		writable: z.boolean(),
+	}),
+]);
+
+const toolProbe = z.discriminatedUnion("status", [
+	z.strictObject({ name: toolName, status: z.literal("absent") }),
+	z.strictObject({
+		name: toolName,
+		path: text,
+		status: z.literal("ready"),
+		version: text,
+	}),
+]);
+
+const packageRecord = z.strictObject({ name: text, version: text });
+const packageProbe = z.discriminatedUnion("manager", [
+	z.strictObject({ manager: z.literal("none"), packages: z.tuple([]) }),
+	z.strictObject({ manager: z.literal("dpkg"), packages: z.array(packageRecord) }),
+]);
+
+export const runnerProbeSchema = z.strictObject({
+	schemaVersion: z.literal(runnerProbeSchemaVersion),
+	environment,
+	identity: z.strictObject({
+		gid: z.number().int().nonnegative(),
+		groups: z.array(text),
+		uid: z.number().int().nonnegative(),
+	}),
+	packages: packageProbe,
+	paths: z.array(pathProbe),
+	platform: z.strictObject({
+		architecture: text,
+		capabilities: text,
+		cgroup: z.enum(["v1", "v2"]),
+		kernelRelease: text,
+		kernelVersion: text,
+		os: z.strictObject({ id: text, prettyName: text, versionId: text }),
+	}),
+	tools: z.array(toolProbe),
+	toolCache: z.record(z.string(), z.array(text)),
+});
+
+export const runnerContractSchema = z.strictObject({
+	schemaVersion: z.literal(runnerProbeSchemaVersion),
+	environment,
+	os: z.strictObject({ id: text, versionId: text }),
+	paths: z.array(pathName),
+	tools: z.array(
+		z.strictObject({
+			name: toolName,
+			versionPrefix: z.string().min(1).optional(),
+		}),
+	),
+});
+
+type DeepReadonly<Value> = Value extends readonly unknown[]
+	? { readonly [Key in keyof Value]: DeepReadonly<Value[Key]> }
+	: Value extends object
+		? { readonly [Key in keyof Value]: DeepReadonly<Value[Key]> }
+		: Value;
+
+export type RunnerEnvironmentName = (typeof runnerEnvironmentNames)[number];
+export type RunnerPathEnvironmentName = (typeof runnerPathEnvironmentNames)[number];
+export type RunnerToolName = (typeof runnerToolNames)[number];
+export type RunnerContract = DeepReadonly<z.infer<typeof runnerContractSchema>>;
+export type RunnerProbe = DeepReadonly<z.infer<typeof runnerProbeSchema>>;
+export type RunnerPackageProbe = RunnerProbe["packages"];
+export type RunnerPathProbe = RunnerProbe["paths"][number];
+export type RunnerToolProbe = RunnerProbe["tools"][number];
+
+export type RunnerDifference = Readonly<{
+	category: "contract" | "inventory" | "provider";
+	actual?: unknown;
+	expected?: unknown;
+	path: string;
+}>;


### PR DESCRIPTION
## Summary

This change adds strict Zod schemas for versioned runner probes and runner contracts. It also adds semantic comparison for contract, inventory, and provider differences.

## Evidence

- Tests reject unknown fields, duplicate names, malformed documents, and incompatible version prefixes.
- The comparison result assigns each difference to one stable category and path.
- Zod 4.4.3 is pinned to an exact version and has no runtime dependencies.

## Tests

- `npm run lint`.
- `npm run typecheck`.
- `npm test`.
- `npm run build`.
- `npm run package`.
- `npm audit --audit-level=high`.
- `npm audit signatures`.

## Compatibility

This change adds public types and functions. Each object schema rejects undeclared fields. Cross-record uniqueness checks remain explicit semantic invariants.

## Review focus

Review schema strictness, uniqueness checks, difference classification, and public exports.
