### PR TITLE
fix(contributors): fail closed on trust state

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Checkout contributor check implementation
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
-          ref: ${{ github.event.pull_request.head.repo.full_name == github.repository && github.sha || github.event.pull_request.base.sha }}
+          ref: ${{ github.event.pull_request.base.sha }}
           persist-credentials: false
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
@@ -45,7 +45,7 @@ jobs:
       - name: Checkout contributor check implementation
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
-          ref: ${{ github.event.pull_request.head.repo.full_name == github.repository && github.sha || github.event.pull_request.base.sha }}
+          ref: ${{ github.event.pull_request.base.sha }}
           persist-credentials: false
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:

--- a/gha/cla.test.ts
+++ b/gha/cla.test.ts
@@ -1,0 +1,32 @@
+import * as assert from "node:assert/strict";
+import { test } from "vitest";
+
+import { checkVouch } from "./cla";
+
+test("denouncement overrides an earlier vouch", async () => {
+	await assert.rejects(
+		() =>
+			checkVouch.run({
+				input: {
+					author: "octocat",
+					bootstrapMaintainers: "windsornguyen",
+					trustedAutomationAuthors: "",
+				},
+				fs: {
+					readText: async () => "github:octocat\n-github:octocat compromised account\n",
+				},
+				log: {
+					group: async (_name, run) => run(),
+					info: () => {},
+					warning: () => {},
+				},
+				call: async () => {
+					throw new Error("unexpected child action call");
+				},
+				exec: async () => ({ exitCode: 0, stdout: "", stderr: "" }),
+				runner: { uidGid: "1001:1001" },
+				summary: { table: async () => {} },
+			}),
+		/@octocat is denounced in VOUCHED\.td: compromised account/,
+	);
+});

--- a/gha/cla.ts
+++ b/gha/cla.ts
@@ -104,6 +104,7 @@ const findContributor = (
 	authorHandle: string,
 ): { readonly denouncedReason?: string } | null => {
 	const authorKey = `github:${authorHandle}`;
+	let isVouched = false;
 	for (const rawLine of vouched.split("\n")) {
 		const line = rawLine.replace(/\r$/, "").trim();
 		if (line.length === 0 || line.startsWith("#")) {
@@ -124,9 +125,9 @@ const findContributor = (
 		if (isDenounced) {
 			return { denouncedReason: reasonParts.join(" ") || "no reason recorded" };
 		}
-		return {};
+		isVouched = true;
 	}
-	return null;
+	return isVouched ? {} : null;
 };
 
 const contributorKey = (rawHandle: string): string => {
@@ -180,7 +181,7 @@ const trustedBaseCheckout = {
 	name: "Checkout contributor check implementation",
 	uses: checkoutAction,
 	with: {
-		ref: "${{ github.event.pull_request.head.repo.full_name == github.repository && github.sha || github.event.pull_request.base.sha }}",
+		ref: "${{ github.event.pull_request.base.sha }}",
 		"persist-credentials": false,
 	},
 } as const;

--- a/gha/dogfood.test.ts
+++ b/gha/dogfood.test.ts
@@ -51,3 +51,11 @@ test("repository workflows bundle ignored local actions before use", () => {
 		}
 	}
 });
+
+test("contributor checks always check out the trusted base commit", () => {
+	for (const contributorJob of [cla.jobs.cla, cla.jobs.vouch]) {
+		const checkout = contributorJob.steps[0];
+		assert.ok(checkout !== undefined && "with" in checkout);
+		assert.equal(checkout.with?.ref, "${{ github.event.pull_request.base.sha }}");
+	}
+});


### PR DESCRIPTION
# Pull Request

## Summary

**What changed:**

Contributor checks now always load their implementation and `VOUCHED.td` from the pull request's trusted base commit. Denouncements also take precedence over an earlier positive entry for the same contributor.

**Why:**

A same-repository branch must not be able to change the trust state used to judge itself, and revocation must fail closed regardless of registry ordering.

> [!IMPORTANT]
> Keep reviewed diffs small. If this adds more than 500 lines outside generated files or lockfiles, split it.

**Lines added, excluding generated files and lockfiles:** 44

## Test Plan

- [x] CLA/Vouch check passes, or this PR only updates `VOUCHED.td`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test` (132 passed, 4 skipped)
- [x] `npm run build`
- [x] `npm run check`
- [x] `npm run package`
- [x] `npm run actions && go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 -color`

## Generated Output

`.github/workflows/cla.yml` was regenerated from `gha/cla.ts`. Both contributor jobs now use:

```yaml
ref: ${{ github.event.pull_request.base.sha }}
```

## Repro / Showcase

Before the fix, the trusted-checkout regression test received the same-repository merge SHA expression instead of `pull_request.base.sha`. The denouncement regression test failed with `Missing expected rejection` for:

```text
github:octocat
-github:octocat compromised account
```

Both regressions now pass.

## Release Impact

- [ ] Runtime/library behavior changed
- [ ] CLI behavior changed
- [x] Generated YAML changed
- [ ] Package contents changed
- [ ] Documentation only
- [ ] N/A

## Compatibility

Contributor Checks no longer execute proposed contributor-action changes from a same-repository pull request. Normal CI still typechecks, tests, builds, and validates the proposed generated workflow.

## Reviewers

- Domain: N/A - the sole CODEOWNER is the PR author
- Readability: N/A - no eligible non-author contributor appears in recent file history

## Notes for Reviewers

The security-sensitive invariants are that both jobs resolve exactly `pull_request.base.sha`, and any matching denouncement wins even if a positive entry appears first.

## Changelog

**[2026-07-30]**

Feedback received:

- (none yet)

Changes made:

- Make both contributor jobs check out the trusted base commit.
- Restore fail-closed denouncement precedence.
- Add focused regressions for both trust boundaries.
