### PR TITLE
feat(workflows): support explicit filenames

### DIFF
--- a/dist/cli.js
+++ b/dist/cli.js
@@ -5853,6 +5853,17 @@ const loadSchema = (schemaFileName) => {
 const workflowParserDistDir = () => dirname(dirname(fileURLToPath(import.meta.resolve("@actions/workflow-parser/workflows/workflow-constants"))));
 //#endregion
 //#region src/generate.ts
+var InvalidWorkflowFilenameError = class extends Error {
+	filename;
+	reason;
+	constructor(filename, reason) {
+		super(`invalid workflow filename ${JSON.stringify(filename)}: ${reason}`);
+		this.name = "InvalidWorkflowFilenameError";
+		this.filename = filename;
+		this.reason = reason;
+	}
+};
+const workflowFilenameKey = Symbol.for("@dedalus-labs/hollywood/workflow-filename");
 const generateActionMetadata = (action) => {
 	const inputs = /* @__PURE__ */ new Map();
 	for (const [name, input] of Object.entries(action.inputs)) {
@@ -5913,7 +5924,8 @@ const generateActionEntrypointFile = (action, options) => {
 };
 const generateWorkflowFile = (options) => ({
 	sourcePath: options.sourcePath,
-	path: `${trimTrailingSlash(options.workflowsDir)}/${flattenSourcePath(options.sourcePath, options.sourceRoot)}.yml`,
+	...options.exportName === void 0 ? {} : { sourceExport: options.exportName },
+	path: `${trimTrailingSlash(options.workflowsDir)}/${workflowFilename(options.workflow) ?? `${flattenSourcePath(options.sourcePath, options.sourceRoot)}.yml`}`,
 	header: generatedHeader(options.generatedAt),
 	workflow: options.workflow
 });
@@ -5984,6 +5996,22 @@ const assertRelativeGeneratedPath = (value, kind) => {
 	const segments = value.split("/");
 	if (value.length === 0 || value.startsWith("/") || value.includes("\\") || segments.some((segment) => segment === "" || segment === "." || segment === "..")) throw new Error(`invalid ${kind}: ${value}`);
 };
+const assertWorkflowFilename = (filename) => {
+	if (filename.length === 0) throw new InvalidWorkflowFilenameError(filename, "filename must not be empty");
+	if (filename !== filename.trim()) throw new InvalidWorkflowFilenameError(filename, "leading or trailing whitespace is not allowed");
+	if (filename.includes("/") || filename.includes("\\")) throw new InvalidWorkflowFilenameError(filename, "filename must not contain directories");
+	const extension = filename.slice(filename.lastIndexOf("."));
+	if (extension !== ".yml" && extension !== ".yaml") throw new InvalidWorkflowFilenameError(filename, "extension must be .yml or .yaml");
+	const stem = filename.slice(0, -extension.length);
+	if (!/^[A-Za-z0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?$/.test(stem)) throw new InvalidWorkflowFilenameError(filename, "name must contain only portable ASCII letters, numbers, dots, hyphens, or underscores");
+};
+const workflowFilename = (definition) => {
+	const filename = definition[workflowFilenameKey];
+	if (filename === void 0) return;
+	if (typeof filename !== "string") throw new InvalidWorkflowFilenameError(String(filename), "filename metadata must be a string");
+	assertWorkflowFilename(filename);
+	return filename;
+};
 const flattenSourcePath = (sourcePath, sourceRoot) => {
 	const root = trimSlashes(sourceRoot);
 	const source = trimSlashes(sourcePath);
@@ -6012,12 +6040,25 @@ const assertTypeScriptIdentifier = (value) => {
 };
 //#endregion
 //#region src/files.ts
+var GeneratedFilePathCollisionError = class extends Error {
+	paths;
+	sources;
+	constructor(first, second) {
+		const paths = [first.path, second.path];
+		const sources = [generatedFileSource(first), generatedFileSource(second)];
+		super(`generated file path collision: ${paths.join(" and ")} from ${sources.join(" and ")}`);
+		this.name = "GeneratedFilePathCollisionError";
+		this.paths = paths;
+		this.sources = sources;
+	}
+};
 const renderGeneratedFile = (file) => ({
 	sourcePath: file.sourcePath,
 	path: file.path,
 	content: generatedFileContent(file)
 });
 const writeGeneratedFiles = async (files, options) => {
+	assertUniqueGeneratedPaths(files);
 	const results = [];
 	for (const file of files) {
 		const rendered = renderGeneratedFile(file);
@@ -6031,6 +6072,16 @@ const writeGeneratedFiles = async (files, options) => {
 		});
 	}
 	return results;
+};
+const generatedFileSource = (file) => "sourceExport" in file && file.sourceExport !== void 0 ? `${file.sourcePath}#${file.sourceExport}` : file.sourcePath;
+const assertUniqueGeneratedPaths = (files) => {
+	const paths = /* @__PURE__ */ new Map();
+	for (const file of files) {
+		const key = file.path.normalize("NFC").toLowerCase();
+		const existing = paths.get(key);
+		if (existing !== void 0) throw new GeneratedFilePathCollisionError(existing, file);
+		paths.set(key, file);
+	}
 };
 const generatedFileContent = (file) => {
 	if ("content" in file) return file.content;
@@ -6633,6 +6684,7 @@ const discoverGeneratedFiles = async (sourceFiles, options) => {
 			}));
 			if (isGitHubWorkflow(value)) files.push(generateWorkflowFile({
 				sourcePath,
+				exportName,
 				sourceRoot: options.sourceRoot,
 				workflowsDir: options.workflowsDir,
 				workflow: value
@@ -6640,7 +6692,6 @@ const discoverGeneratedFiles = async (sourceFiles, options) => {
 		}
 	}
 	if (files.length === 0) throw new Error(`no Hollywood actions or workflows exported by: ${sourceFiles.join(", ")}`);
-	assertUniqueGeneratedPaths(files);
 	return files;
 };
 const loadHollywoodModule = async (sourceFile) => {
@@ -6726,13 +6777,6 @@ const relativeSourcePath = (outputDir, sourceFile) => {
 };
 const isScriptAction = (value) => typeof value === "object" && value !== null && typeof value.name === "string" && typeof value.description === "string" && typeof value.inputs === "object" && value.inputs !== null && typeof value.outputs === "object" && value.outputs !== null && typeof value.run === "function";
 const isGitHubWorkflow = (value) => typeof value === "object" && value !== null && typeof value.name === "string" && typeof value.on === "object" && value.on !== null && typeof value.jobs === "object" && value.jobs !== null;
-const assertUniqueGeneratedPaths = (files) => {
-	const paths = /* @__PURE__ */ new Set();
-	for (const file of files) {
-		if (paths.has(file.path)) throw new Error(`duplicate generated file path: ${file.path}`);
-		paths.add(file.path);
-	}
-};
 const processIo = () => ({ writeOut: (message) => {
 	process.stdout.write(message);
 } });

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -203,11 +203,20 @@ type GitHubWorkflowJobs = {
 };
 type GitHubWorkflowFile = Readonly<{
   sourcePath: string;
+  sourceExport?: string;
   path: string;
   header: string;
   workflow: GitHubWorkflow;
 }>;
-declare const workflow: <const Workflow extends GitHubWorkflow>(definition: Workflow) => Workflow;
+type GitHubWorkflowOptions = Readonly<{
+  filename: string;
+}>;
+declare class InvalidWorkflowFilenameError extends Error {
+  readonly filename: string;
+  readonly reason: string;
+  constructor(filename: string, reason: string);
+}
+declare const workflow: <const Workflow extends GitHubWorkflow>(definition: Workflow, options?: GitHubWorkflowOptions) => Workflow;
 declare const job: <const Job extends GitHubWorkflowJob>(definition: Job) => Job;
 declare const localAction: <const Inputs extends InputDefinitions>(definition: GitHubLocalAction<Inputs>) => GitHubLocalAction<Inputs>;
 declare const generateActionMetadata: <const Inputs extends InputDefinitions, const Outputs extends OutputDefinitions>(action: ScriptActionDescriptor<Inputs, Outputs>) => GitHubActionMetadata;
@@ -235,6 +244,7 @@ declare const generateWorkflowFile: (options: Readonly<{
   sourcePath: string;
   sourceRoot: string;
   workflowsDir: string;
+  exportName?: string;
   generatedAt?: Date;
   workflow: GitHubWorkflow;
 }>) => GitHubWorkflowFile;
@@ -258,6 +268,11 @@ type GeneratedFileWriteResult = Readonly<{
 type WriteGeneratedFilesOptions = Readonly<{
   outputDir: string;
 }>;
+declare class GeneratedFilePathCollisionError extends Error {
+  readonly paths: readonly string[];
+  readonly sources: readonly string[];
+  constructor(first: GeneratedFile, second: GeneratedFile);
+}
 declare const renderGeneratedFile: (file: GeneratedFile) => RenderedGeneratedFile;
 declare const writeGeneratedFiles: (files: readonly GeneratedFile[], options: WriteGeneratedFilesOptions) => Promise<readonly GeneratedFileWriteResult[]>;
 //#endregion
@@ -308,4 +323,4 @@ declare const probeLimaEnvironment: (probe: LimaEnvironmentProbe) => Promise<Lim
 declare const limaExec: (options: LimaExecOptions) => ScriptExec;
 declare const limaRunner: (options: LimaExecOptions) => Promise<RunnerContext>;
 //#endregion
-export { type AccountName, type ActionCallInputValues, type ActionInputValues, type ActionOutputValues, type ChoiceInputDefinition, type Command, type CommandEnvironment, type CommandExitPolicy, type CommandOptions, type CommandResult, type EnvironmentAccount, type EnvironmentAccounts, type EnvironmentDefinition, type EnvironmentDefinitions, type EnvironmentName, type EnvironmentRegistry, type EnvironmentSelector, type GeneratedFile, type GeneratedFileWriteResult, type GeneratedFileWriteStatus, type GitHubActionEntrypointFile, type GitHubActionFile, type GitHubActionInputMetadata, type GitHubActionMetadata, type GitHubActionOutputMetadata, type GitHubConcurrency, type GitHubCore, type GitHubEnvironmentVariables, type GitHubExec, type GitHubExecOptions, type GitHubExpression, type GitHubExpressionString, type GitHubExpressionValue, type GitHubInputOptions, type GitHubJobOutputs, GitHubJobResult, type GitHubJobResultValue, type GitHubLocalAction, type GitHubLocalActionStepOptions, type GitHubLogColor, type GitHubMatrix, type GitHubMatrixObject, type GitHubMatrixValue, type GitHubMatrixValues, type GitHubNeeds, type GitHubPermission, type GitHubPermissions, type GitHubReusableWorkflowJob, type GitHubReusableWorkflowSecrets, type GitHubRunStep, type GitHubService, type GitHubServices, type GitHubStepWorkflowJob, type GitHubStrategy, type GitHubTypedMatrix, type GitHubUsesStep, type GitHubUsesStepOptions, type GitHubWithValues, type GitHubWorkflow, type GitHubWorkflowCallWithValues, type GitHubWorkflowFile, type GitHubWorkflowJob, type GitHubWorkflowStep, type GitHubYamlFile, type GitHubYamlValidation, type GitHubYamlValidationError, type InputDefinition, type InputDefinitions, type InputKind, type LimaContainerRuntime, type LimaEnvironmentProbe, type LimaEnvironmentResult, type LimaExecOptions, type OutputDefinition, type OutputDefinitions, type RenderedGeneratedFile, type ResolvedEnvironment, type RunActionOptions, type RunGitHubActionOptions, type RunnerContext, type ScriptAction, type ScriptActionCall, type ScriptActionContext, type ScriptActionServices, type ScriptExec, type ScriptFs, type ScriptLog, type ScriptSummary, type SummaryCell, type SummaryCode, type SummaryTableRow, type SummaryText, type WorkflowInputValues, type WriteGeneratedFilesOptions, action, always, and, assertValidActionMetadataContent, assertValidWorkflowContent, booleanInput, cancelled, choiceInput, contains, currentRunner, defineEnvironmentRegistry, defineMatrix, envVar, eq, expr, failure, format, generateActionEntrypointFile, generateActionFile, generateActionFiles, generateActionMetadata, generateUsesStep, generateWorkflowFile, gh, github, hashFiles, input, integerInput, job, limaExec, limaRunner, localAction, matrix, ne, needsOutput, needsResult, needsResultIn, needsResultIs, nodeExec, nodeFs, nodeLog, not, or, pathInput, probeLimaEnvironment, renderActionFile, renderGeneratedFile, renderWorkflowFile, resolveEnvironment, runAction, runGitHubAction, runner, secret, selectEnvironmentName, selectString, stepOutput, stringInput, stringOutput, success, summaryCode, summaryText, uses, validateActionMetadataContent, validateWorkflowContent, valueOr, workflow, writeGeneratedFiles };
+export { type AccountName, type ActionCallInputValues, type ActionInputValues, type ActionOutputValues, type ChoiceInputDefinition, type Command, type CommandEnvironment, type CommandExitPolicy, type CommandOptions, type CommandResult, type EnvironmentAccount, type EnvironmentAccounts, type EnvironmentDefinition, type EnvironmentDefinitions, type EnvironmentName, type EnvironmentRegistry, type EnvironmentSelector, type GeneratedFile, GeneratedFilePathCollisionError, type GeneratedFileWriteResult, type GeneratedFileWriteStatus, type GitHubActionEntrypointFile, type GitHubActionFile, type GitHubActionInputMetadata, type GitHubActionMetadata, type GitHubActionOutputMetadata, type GitHubConcurrency, type GitHubCore, type GitHubEnvironmentVariables, type GitHubExec, type GitHubExecOptions, type GitHubExpression, type GitHubExpressionString, type GitHubExpressionValue, type GitHubInputOptions, type GitHubJobOutputs, GitHubJobResult, type GitHubJobResultValue, type GitHubLocalAction, type GitHubLocalActionStepOptions, type GitHubLogColor, type GitHubMatrix, type GitHubMatrixObject, type GitHubMatrixValue, type GitHubMatrixValues, type GitHubNeeds, type GitHubPermission, type GitHubPermissions, type GitHubReusableWorkflowJob, type GitHubReusableWorkflowSecrets, type GitHubRunStep, type GitHubService, type GitHubServices, type GitHubStepWorkflowJob, type GitHubStrategy, type GitHubTypedMatrix, type GitHubUsesStep, type GitHubUsesStepOptions, type GitHubWithValues, type GitHubWorkflow, type GitHubWorkflowCallWithValues, type GitHubWorkflowFile, type GitHubWorkflowJob, type GitHubWorkflowOptions, type GitHubWorkflowStep, type GitHubYamlFile, type GitHubYamlValidation, type GitHubYamlValidationError, type InputDefinition, type InputDefinitions, type InputKind, InvalidWorkflowFilenameError, type LimaContainerRuntime, type LimaEnvironmentProbe, type LimaEnvironmentResult, type LimaExecOptions, type OutputDefinition, type OutputDefinitions, type RenderedGeneratedFile, type ResolvedEnvironment, type RunActionOptions, type RunGitHubActionOptions, type RunnerContext, type ScriptAction, type ScriptActionCall, type ScriptActionContext, type ScriptActionServices, type ScriptExec, type ScriptFs, type ScriptLog, type ScriptSummary, type SummaryCell, type SummaryCode, type SummaryTableRow, type SummaryText, type WorkflowInputValues, type WriteGeneratedFilesOptions, action, always, and, assertValidActionMetadataContent, assertValidWorkflowContent, booleanInput, cancelled, choiceInput, contains, currentRunner, defineEnvironmentRegistry, defineMatrix, envVar, eq, expr, failure, format, generateActionEntrypointFile, generateActionFile, generateActionFiles, generateActionMetadata, generateUsesStep, generateWorkflowFile, gh, github, hashFiles, input, integerInput, job, limaExec, limaRunner, localAction, matrix, ne, needsOutput, needsResult, needsResultIn, needsResultIs, nodeExec, nodeFs, nodeLog, not, or, pathInput, probeLimaEnvironment, renderActionFile, renderGeneratedFile, renderWorkflowFile, resolveEnvironment, runAction, runGitHubAction, runner, secret, selectEnvironmentName, selectString, stepOutput, stringInput, stringOutput, success, summaryCode, summaryText, uses, validateActionMetadataContent, validateWorkflowContent, valueOr, workflow, writeGeneratedFiles };

--- a/dist/index.js
+++ b/dist/index.js
@@ -60,7 +60,24 @@ const loadSchema = (schemaFileName) => {
 const workflowParserDistDir = () => dirname$1(dirname$1(fileURLToPath(import.meta.resolve("@actions/workflow-parser/workflows/workflow-constants"))));
 //#endregion
 //#region src/generate.ts
-const workflow = (definition) => definition;
+var InvalidWorkflowFilenameError = class extends Error {
+	filename;
+	reason;
+	constructor(filename, reason) {
+		super(`invalid workflow filename ${JSON.stringify(filename)}: ${reason}`);
+		this.name = "InvalidWorkflowFilenameError";
+		this.filename = filename;
+		this.reason = reason;
+	}
+};
+const workflowFilenameKey = Symbol.for("@dedalus-labs/hollywood/workflow-filename");
+const workflow = (definition, options) => {
+	if (options === void 0) return definition;
+	assertWorkflowFilename(options.filename);
+	const configured = { ...definition };
+	Object.defineProperty(configured, workflowFilenameKey, { value: options.filename });
+	return configured;
+};
 const job = (definition) => definition;
 const localAction = (definition) => definition;
 const generateActionMetadata = (action) => {
@@ -154,7 +171,8 @@ const uses = (action, options) => {
 };
 const generateWorkflowFile = (options) => ({
 	sourcePath: options.sourcePath,
-	path: `${trimTrailingSlash(options.workflowsDir)}/${flattenSourcePath(options.sourcePath, options.sourceRoot)}.yml`,
+	...options.exportName === void 0 ? {} : { sourceExport: options.exportName },
+	path: `${trimTrailingSlash(options.workflowsDir)}/${workflowFilename(options.workflow) ?? `${flattenSourcePath(options.sourcePath, options.sourceRoot)}.yml`}`,
 	header: generatedHeader(options.generatedAt),
 	workflow: options.workflow
 });
@@ -232,6 +250,22 @@ const assertRelativeGeneratedPath = (value, kind) => {
 	const segments = value.split("/");
 	if (value.length === 0 || value.startsWith("/") || value.includes("\\") || segments.some((segment) => segment === "" || segment === "." || segment === "..")) throw new Error(`invalid ${kind}: ${value}`);
 };
+const assertWorkflowFilename = (filename) => {
+	if (filename.length === 0) throw new InvalidWorkflowFilenameError(filename, "filename must not be empty");
+	if (filename !== filename.trim()) throw new InvalidWorkflowFilenameError(filename, "leading or trailing whitespace is not allowed");
+	if (filename.includes("/") || filename.includes("\\")) throw new InvalidWorkflowFilenameError(filename, "filename must not contain directories");
+	const extension = filename.slice(filename.lastIndexOf("."));
+	if (extension !== ".yml" && extension !== ".yaml") throw new InvalidWorkflowFilenameError(filename, "extension must be .yml or .yaml");
+	const stem = filename.slice(0, -extension.length);
+	if (!/^[A-Za-z0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?$/.test(stem)) throw new InvalidWorkflowFilenameError(filename, "name must contain only portable ASCII letters, numbers, dots, hyphens, or underscores");
+};
+const workflowFilename = (definition) => {
+	const filename = definition[workflowFilenameKey];
+	if (filename === void 0) return;
+	if (typeof filename !== "string") throw new InvalidWorkflowFilenameError(String(filename), "filename metadata must be a string");
+	assertWorkflowFilename(filename);
+	return filename;
+};
 const flattenSourcePath = (sourcePath, sourceRoot) => {
 	const root = trimSlashes(sourceRoot);
 	const source = trimSlashes(sourcePath);
@@ -260,12 +294,25 @@ const assertTypeScriptIdentifier = (value) => {
 };
 //#endregion
 //#region src/files.ts
+var GeneratedFilePathCollisionError = class extends Error {
+	paths;
+	sources;
+	constructor(first, second) {
+		const paths = [first.path, second.path];
+		const sources = [generatedFileSource(first), generatedFileSource(second)];
+		super(`generated file path collision: ${paths.join(" and ")} from ${sources.join(" and ")}`);
+		this.name = "GeneratedFilePathCollisionError";
+		this.paths = paths;
+		this.sources = sources;
+	}
+};
 const renderGeneratedFile = (file) => ({
 	sourcePath: file.sourcePath,
 	path: file.path,
 	content: generatedFileContent(file)
 });
 const writeGeneratedFiles = async (files, options) => {
+	assertUniqueGeneratedPaths(files);
 	const results = [];
 	for (const file of files) {
 		const rendered = renderGeneratedFile(file);
@@ -279,6 +326,16 @@ const writeGeneratedFiles = async (files, options) => {
 		});
 	}
 	return results;
+};
+const generatedFileSource = (file) => "sourceExport" in file && file.sourceExport !== void 0 ? `${file.sourcePath}#${file.sourceExport}` : file.sourcePath;
+const assertUniqueGeneratedPaths = (files) => {
+	const paths = /* @__PURE__ */ new Map();
+	for (const file of files) {
+		const key = file.path.normalize("NFC").toLowerCase();
+		const existing = paths.get(key);
+		if (existing !== void 0) throw new GeneratedFilePathCollisionError(existing, file);
+		paths.set(key, file);
+	}
 };
 const generatedFileContent = (file) => {
 	if ("content" in file) return file.content;
@@ -394,4 +451,4 @@ const reject = (name, reason) => ({
 	reason
 });
 //#endregion
-export { GitHubJobResult, action, always, and, assertValidActionMetadataContent, assertValidWorkflowContent, booleanInput, cancelled, choiceInput, contains, currentRunner, defineEnvironmentRegistry, defineMatrix, envVar, eq, expr, failure, format, generateActionEntrypointFile, generateActionFile, generateActionFiles, generateActionMetadata, generateUsesStep, generateWorkflowFile, gh, github, hashFiles, input, integerInput, job, limaExec, limaRunner, localAction, matrix, ne, needsOutput, needsResult, needsResultIn, needsResultIs, nodeExec, nodeFs, nodeLog, not, or, pathInput, probeLimaEnvironment, renderActionFile, renderGeneratedFile, renderWorkflowFile, resolveEnvironment, runAction, runGitHubAction, runner, secret, selectEnvironmentName, selectString, stepOutput, stringInput, stringOutput, success, summaryCode, summaryText, uses, validateActionMetadataContent, validateWorkflowContent, valueOr, workflow, writeGeneratedFiles };
+export { GeneratedFilePathCollisionError, GitHubJobResult, InvalidWorkflowFilenameError, action, always, and, assertValidActionMetadataContent, assertValidWorkflowContent, booleanInput, cancelled, choiceInput, contains, currentRunner, defineEnvironmentRegistry, defineMatrix, envVar, eq, expr, failure, format, generateActionEntrypointFile, generateActionFile, generateActionFiles, generateActionMetadata, generateUsesStep, generateWorkflowFile, gh, github, hashFiles, input, integerInput, job, limaExec, limaRunner, localAction, matrix, ne, needsOutput, needsResult, needsResultIn, needsResultIs, nodeExec, nodeFs, nodeLog, not, or, pathInput, probeLimaEnvironment, renderActionFile, renderGeneratedFile, renderWorkflowFile, resolveEnvironment, runAction, runGitHubAction, runner, secret, selectEnvironmentName, selectString, stepOutput, stringInput, stringOutput, success, summaryCode, summaryText, uses, validateActionMetadataContent, validateWorkflowContent, valueOr, workflow, writeGeneratedFiles };

--- a/docs/reference/generated-files.md
+++ b/docs/reference/generated-files.md
@@ -80,3 +80,7 @@ The GitHub workflow output is flat:
 
 That satisfies GitHub's directory shape without forcing humans to keep every
 workflow source file in one directory.
+
+`workflow(definition, { filename: "release.yml" })` overrides the flattened name.
+Filenames cannot contain directories, and case-insensitive collisions fail
+before Hollywood writes any generated file.

--- a/docs/usage/github-actions.md
+++ b/docs/usage/github-actions.md
@@ -164,7 +164,7 @@ generateWorkflowFile({
 				],
 			}),
 		},
-	}),
+	}, { filename: "container-release.yml" }),
 });
 ```
 
@@ -179,6 +179,11 @@ becomes:
 ```text
 .github/workflows/containers-release.yml
 ```
+
+Pass `{ filename: "container-release.yml" }` to `workflow` when the output name
+must be independent of the source layout. Hollywood rejects directory paths,
+non-portable names, unsupported extensions, and case-insensitive collisions
+before writing any generated file.
 
 GitHub gets the flat shape it requires. The source tree keeps the nested shape
 humans want.

--- a/src/commands.test.ts
+++ b/src/commands.test.ts
@@ -1,10 +1,11 @@
 import * as assert from "node:assert/strict";
-import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { test } from "vitest";
 
 import { buildActions, check, createCli, generate, run } from "./commands";
+import { GeneratedFilePathCollisionError } from "./files";
 
 test("generate discovers exported actions from source files", async () => {
 	const root = await mkdtemp(join(tmpdir(), "hollywood-cli-"));
@@ -82,6 +83,44 @@ test("generate discovers exported workflows from globbed source files", async ()
 		await readFile(join(root, ".github/workflows/containers-release.yml"), "utf8"),
 		/name: Container Release/,
 	);
+});
+
+test("generate rejects case-insensitive workflow filename collisions before writing", async () => {
+	const root = await mkdtemp(join(tmpdir(), "hollywood-cli-"));
+	const cdSource = join(root, "automation/cd/release.ts");
+	const ciSource = join(root, "automation/ci/release.ts");
+	await symlink(join(process.cwd(), "node_modules"), join(root, "node_modules"), "dir");
+
+	const source = (name: string, filename: string): readonly string[] => [
+		'import { workflow } from "@dedalus-labs/hollywood";',
+		`export const release = workflow({ name: "${name}", on: { push: {} }, jobs: {} },`,
+		`  { filename: "${filename}" });`,
+		"",
+	];
+	await writeSource(cdSource, source("Release", "release.yml"));
+	await writeSource(ciSource, source("Verify release", "RELEASE.yml"));
+
+	await assert.rejects(
+		() =>
+			generate(
+				{
+					actionsDir: ".github/actions",
+					output: root,
+					sourceRoot: "automation",
+					sources: [join(root, "automation/**/*.ts")],
+					workflowsDir: ".github/workflows",
+				},
+				{ writeOut: () => {} },
+			),
+		(error: unknown) =>
+			error instanceof GeneratedFilePathCollisionError &&
+			/generated file path collision: .*release\.yml.*automation\/cd\/release\.ts#release.*automation\/ci\/release\.ts#release/is.test(
+				error.message,
+			),
+	);
+	await assert.rejects(() => readFile(join(root, ".github/workflows/release.yml"), "utf8"), {
+		code: "ENOENT",
+	});
 });
 
 test("generate ignores test sources matched by workflow globs", async () => {

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -658,6 +658,7 @@ const discoverGeneratedFiles = async (
 				files.push(
 					generateWorkflowFile({
 						sourcePath,
+						exportName,
 						sourceRoot: options.sourceRoot,
 						workflowsDir: options.workflowsDir,
 						workflow: value,
@@ -669,7 +670,6 @@ const discoverGeneratedFiles = async (
 	if (files.length === 0) {
 		throw new Error(`no Hollywood actions or workflows exported by: ${sourceFiles.join(", ")}`);
 	}
-	assertUniqueGeneratedPaths(files);
 	return files;
 };
 
@@ -787,16 +787,6 @@ const isGitHubWorkflow = (value: unknown): value is GitHubWorkflow =>
 	(value as { readonly on?: unknown }).on !== null &&
 	typeof (value as { readonly jobs?: unknown }).jobs === "object" &&
 	(value as { readonly jobs?: unknown }).jobs !== null;
-
-const assertUniqueGeneratedPaths = (files: readonly GeneratedFile[]): void => {
-	const paths = new Set<string>();
-	for (const file of files) {
-		if (paths.has(file.path)) {
-			throw new Error(`duplicate generated file path: ${file.path}`);
-		}
-		paths.add(file.path);
-	}
-};
 
 const processIo = (): CliIo => ({
 	writeOut: (message) => {

--- a/src/files.ts
+++ b/src/files.ts
@@ -25,6 +25,20 @@ export type WriteGeneratedFilesOptions = Readonly<{
 	outputDir: string;
 }>;
 
+export class GeneratedFilePathCollisionError extends Error {
+	readonly paths: readonly string[];
+	readonly sources: readonly string[];
+
+	constructor(first: GeneratedFile, second: GeneratedFile) {
+		const paths = [first.path, second.path];
+		const sources = [generatedFileSource(first), generatedFileSource(second)];
+		super(`generated file path collision: ${paths.join(" and ")} from ${sources.join(" and ")}`);
+		this.name = "GeneratedFilePathCollisionError";
+		this.paths = paths;
+		this.sources = sources;
+	}
+}
+
 export const renderGeneratedFile = (file: GeneratedFile): RenderedGeneratedFile => ({
 	sourcePath: file.sourcePath,
 	path: file.path,
@@ -35,6 +49,7 @@ export const writeGeneratedFiles = async (
 	files: readonly GeneratedFile[],
 	options: WriteGeneratedFilesOptions,
 ): Promise<readonly GeneratedFileWriteResult[]> => {
+	assertUniqueGeneratedPaths(files);
 	const results: GeneratedFileWriteResult[] = [];
 	for (const file of files) {
 		const rendered = renderGeneratedFile(file);
@@ -48,6 +63,23 @@ export const writeGeneratedFiles = async (
 		});
 	}
 	return results;
+};
+
+const generatedFileSource = (file: GeneratedFile): string =>
+	"sourceExport" in file && file.sourceExport !== undefined
+		? `${file.sourcePath}#${file.sourceExport}`
+		: file.sourcePath;
+
+const assertUniqueGeneratedPaths = (files: readonly GeneratedFile[]): void => {
+	const paths = new Map<string, GeneratedFile>();
+	for (const file of files) {
+		const key = file.path.normalize("NFC").toLowerCase();
+		const existing = paths.get(key);
+		if (existing !== undefined) {
+			throw new GeneratedFilePathCollisionError(existing, file);
+		}
+		paths.set(key, file);
+	}
 };
 
 const generatedFileContent = (file: GeneratedFile): string => {

--- a/src/generate.test.ts
+++ b/src/generate.test.ts
@@ -8,6 +8,7 @@ import {
 	generateActionMetadata,
 	generateUsesStep,
 	generateWorkflowFile,
+	InvalidWorkflowFilenameError,
 	job,
 	localAction,
 	renderActionFile,
@@ -528,6 +529,45 @@ test("generateWorkflowFile flattens nested workflow sources into .github workflo
 				},
 			},
 		},
+	);
+});
+
+test("generateWorkflowFile honors an explicit workflow filename", () => {
+	const namedWorkflow = workflow(
+		{
+			name: "Container Release",
+			on: { workflow_dispatch: {} },
+			jobs: {},
+		},
+		{ filename: "release.yml" },
+	);
+
+	const file = generateWorkflowFile({
+		sourcePath: "automation/cd/container.ts",
+		sourceRoot: "automation",
+		workflowsDir: ".github/workflows",
+		workflow: namedWorkflow,
+	});
+
+	assert.equal(file.path, ".github/workflows/release.yml");
+	assert.doesNotMatch(renderWorkflowFile(file), /filename/);
+});
+
+test.each([
+	"",
+	" release.yml",
+	"release.yml ",
+	"../release.yml",
+	"nested/release.yml",
+	"nested\\release.yml",
+	".yml",
+	"release.txt",
+	"release.YML",
+	"r\u00e9lease.yml",
+])("workflow rejects invalid explicit filename %j", (filename) => {
+	assert.throws(
+		() => workflow({ name: "Release", on: { workflow_dispatch: {} }, jobs: {} }, { filename }),
+		InvalidWorkflowFilenameError,
 	);
 });
 

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -276,13 +276,42 @@ export type GitHubWorkflowJobs = {
 
 export type GitHubWorkflowFile = Readonly<{
 	sourcePath: string;
+	sourceExport?: string;
 	path: string;
 	header: string;
 	workflow: GitHubWorkflow;
 }>;
 
-export const workflow = <const Workflow extends GitHubWorkflow>(definition: Workflow): Workflow =>
-	definition;
+export type GitHubWorkflowOptions = Readonly<{
+	filename: string;
+}>;
+
+export class InvalidWorkflowFilenameError extends Error {
+	readonly filename: string;
+	readonly reason: string;
+
+	constructor(filename: string, reason: string) {
+		super(`invalid workflow filename ${JSON.stringify(filename)}: ${reason}`);
+		this.name = "InvalidWorkflowFilenameError";
+		this.filename = filename;
+		this.reason = reason;
+	}
+}
+
+const workflowFilenameKey = Symbol.for("@dedalus-labs/hollywood/workflow-filename");
+
+export const workflow = <const Workflow extends GitHubWorkflow>(
+	definition: Workflow,
+	options?: GitHubWorkflowOptions,
+): Workflow => {
+	if (options === undefined) {
+		return definition;
+	}
+	assertWorkflowFilename(options.filename);
+	const configured = { ...definition };
+	Object.defineProperty(configured, workflowFilenameKey, { value: options.filename });
+	return configured as Workflow;
+};
 
 export const job = <const Job extends GitHubWorkflowJob>(definition: Job): Job => definition;
 
@@ -446,15 +475,14 @@ export const generateWorkflowFile = (
 		sourcePath: string;
 		sourceRoot: string;
 		workflowsDir: string;
+		exportName?: string;
 		generatedAt?: Date;
 		workflow: GitHubWorkflow;
 	}>,
 ): GitHubWorkflowFile => ({
 	sourcePath: options.sourcePath,
-	path: `${trimTrailingSlash(options.workflowsDir)}/${flattenSourcePath(
-		options.sourcePath,
-		options.sourceRoot,
-	)}.yml`,
+	...(options.exportName === undefined ? {} : { sourceExport: options.exportName }),
+	path: `${trimTrailingSlash(options.workflowsDir)}/${workflowFilename(options.workflow) ?? `${flattenSourcePath(options.sourcePath, options.sourceRoot)}.yml`}`,
 	header: generatedHeader(options.generatedAt),
 	workflow: options.workflow,
 });
@@ -576,6 +604,41 @@ const assertRelativeGeneratedPath = (value: string, kind: string): void => {
 	) {
 		throw new Error(`invalid ${kind}: ${value}`);
 	}
+};
+
+const assertWorkflowFilename = (filename: string): void => {
+	if (filename.length === 0) {
+		throw new InvalidWorkflowFilenameError(filename, "filename must not be empty");
+	}
+	if (filename !== filename.trim()) {
+		throw new InvalidWorkflowFilenameError(filename, "leading or trailing whitespace is not allowed");
+	}
+	if (filename.includes("/") || filename.includes("\\")) {
+		throw new InvalidWorkflowFilenameError(filename, "filename must not contain directories");
+	}
+	const extension = filename.slice(filename.lastIndexOf("."));
+	if (extension !== ".yml" && extension !== ".yaml") {
+		throw new InvalidWorkflowFilenameError(filename, "extension must be .yml or .yaml");
+	}
+	const stem = filename.slice(0, -extension.length);
+	if (!/^[A-Za-z0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?$/.test(stem)) {
+		throw new InvalidWorkflowFilenameError(
+			filename,
+			"name must contain only portable ASCII letters, numbers, dots, hyphens, or underscores",
+		);
+	}
+};
+
+const workflowFilename = (definition: GitHubWorkflow): string | undefined => {
+	const filename = (definition as Readonly<Record<symbol, unknown>>)[workflowFilenameKey];
+	if (filename === undefined) {
+		return undefined;
+	}
+	if (typeof filename !== "string") {
+		throw new InvalidWorkflowFilenameError(String(filename), "filename metadata must be a string");
+	}
+	assertWorkflowFilename(filename);
+	return filename;
 };
 
 const flattenSourcePath = (sourcePath: string, sourceRoot: string): string => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -85,6 +85,7 @@ export type {
 	GitHubWorkflow,
 	GitHubWorkflowFile,
 	GitHubWorkflowJob,
+	GitHubWorkflowOptions,
 	GitHubWorkflowStep,
 } from "./generate";
 export {
@@ -94,6 +95,7 @@ export {
 	generateActionMetadata,
 	generateUsesStep,
 	generateWorkflowFile,
+	InvalidWorkflowFilenameError,
 	job,
 	localAction,
 	renderActionFile,
@@ -165,7 +167,11 @@ export type {
 	RenderedGeneratedFile,
 	WriteGeneratedFilesOptions,
 } from "./files";
-export { renderGeneratedFile, writeGeneratedFiles } from "./files";
+export {
+	GeneratedFilePathCollisionError,
+	renderGeneratedFile,
+	writeGeneratedFiles,
+} from "./files";
 
 export type { GitHubYamlFile, GitHubYamlValidation, GitHubYamlValidationError } from "./validation";
 export {


### PR DESCRIPTION
# Pull Request

## Summary

**What changed:**

Added opt-in explicit filenames for typed workflows and fail-closed generated-path collision detection with source-export diagnostics.

**Why:**

Repositories can organize workflow sources by lifecycle without encoding that source layout into GitHub's flat workflow filenames or risking silent overwrites.

> [!IMPORTANT]
> Keep reviewed diffs small. If this adds more than 500 lines outside generated files or lockfiles, split it.

**Lines added, excluding generated files and lockfiles:** 199

## Test Plan

- [x] CLA/Vouch check passes, or this PR only updates `VOUCHED.td`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test`
- [x] `npm run build`
- [x] `npm run check`
- [x] `npm run package`

## Generated Output

The repository's committed generated actions and workflows remain unchanged under `npm run generate`. An opt-in workflow declared with `{ filename: "release.yml" }` now generates `.github/workflows/release.yml` regardless of its source directory.

## Repro / Showcase

The pre-implementation focused suite failed 12 new assertions: explicit names were ignored, invalid names were accepted, and case-insensitive collisions were written. The implementation passes all 71 focused tests and the full suite of 144 tests (4 skipped). The collision test also proves neither conflicting file is written and the typed error names both source exports.

## Release Impact

- [x] Runtime/library behavior changed
- [x] CLI behavior changed
- [ ] Generated YAML changed
- [x] Package contents changed
- [ ] Documentation only
- [ ] N/A

## Compatibility

Backward compatible. Existing `workflow(definition)` calls and source-derived filenames are unchanged. Explicit filenames are opt-in.

## Reviewers

- Domain: @helenhuidedalus
- Readability: @tsiongk

## Notes for Reviewers

Filename metadata is stored on a non-enumerable global symbol so it survives package/CLI module boundaries without entering generated YAML. Validation accepts only portable `.yml` or `.yaml` basenames. Collision comparison normalizes Unicode and ignores case, then fails before the writer creates any output.

Closes #56.

## Changelog

**2026-08-12**

Feedback received:

- (none yet)

Changes made:

- Added opt-in explicit workflow filenames.
- Added typed filename and collision errors.
- Added pre-write case-insensitive collision detection.