### PR TITLE
fix(ci): make required checks queue-ready

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
   pull_request:
     branches:
       - main
+  merge_group:
+    types:
+      - checks_requested
 permissions:
   contents: read
 jobs:

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -10,11 +10,15 @@ on:
       - reopened
       - synchronize
       - ready_for_review
+  merge_group:
+    types:
+      - checks_requested
 permissions:
   contents: read
 jobs:
   cla:
     name: CLA
+    if: ${{ github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout contributor check implementation
@@ -39,6 +43,7 @@ jobs:
           trusted-automation-authors: cind-bot[bot] cind[bot]
   vouch:
     name: Vouch
+    if: ${{ github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
     needs: cla
     steps:

--- a/gha/ci.ts
+++ b/gha/ci.ts
@@ -80,6 +80,7 @@ export const ci = workflow({
 	on: {
 		push: { branches: ["main"] },
 		pull_request: { branches: ["main"] },
+		merge_group: { types: ["checks_requested"] },
 	},
 	permissions: { contents: "read" },
 	jobs: {

--- a/gha/cla.ts
+++ b/gha/cla.ts
@@ -1,5 +1,7 @@
 import {
 	action,
+	eq,
+	github,
 	job,
 	stringInput,
 	uses,
@@ -214,11 +216,13 @@ export const cla = workflow({
 			branches: ["main"],
 			types: ["opened", "reopened", "synchronize", "ready_for_review"],
 		},
+		merge_group: { types: ["checks_requested"] },
 	},
 	permissions: { contents: "read" },
 	jobs: {
 		cla: job({
 			name: "CLA",
+			if: eq(github.eventName, "pull_request"),
 			"runs-on": "ubuntu-latest",
 			steps: [
 				...prepareHollywood,
@@ -230,6 +234,7 @@ export const cla = workflow({
 		}),
 		vouch: job({
 			name: "Vouch",
+			if: eq(github.eventName, "pull_request"),
 			"runs-on": "ubuntu-latest",
 			needs: "cla",
 			steps: [

--- a/gha/dogfood.test.ts
+++ b/gha/dogfood.test.ts
@@ -59,3 +59,11 @@ test("contributor checks always check out the trusted base commit", () => {
 		assert.equal(checkout.with?.ref, "${{ github.event.pull_request.base.sha }}");
 	}
 });
+
+test("required checks report on merge queue heads", () => {
+	assert.deepEqual(ci.on.merge_group, { types: ["checks_requested"] });
+	assert.deepEqual(cla.on.merge_group, { types: ["checks_requested"] });
+	for (const contributorJob of [cla.jobs.cla, cla.jobs.vouch]) {
+		assert.equal(contributorJob.if, "${{ github.event_name == 'pull_request' }}");
+	}
+});


### PR DESCRIPTION
## Summary

- trigger required CI and contributor-check workflows for GitHub merge groups
- run Test and Actionlint against the projected queue head
- report CLA and Vouch as skipped-success after their PR-head checks gated queue admission

## Validation

- `npm run lint`
- `npm run typecheck`
- `npm test` (146 passed, 4 skipped)
- `npm run check`
- `git diff --check`

GitHub requires required Actions workflows to handle `merge_group`; otherwise a native merge queue waits for checks that never report.