### PR TITLE
fix(release): create immutable tags explicitly

### DIFF
--- a/gha/release.test.ts
+++ b/gha/release.test.ts
@@ -70,6 +70,8 @@ test("release please owns independent npm and runner versions", async () => {
 	) as Record<string, unknown>;
 
 	assert.equal(config["separate-pull-requests"], true);
+	assert.equal(config["force-tag-creation"], true);
+	assert.equal(config["include-component-in-tag"], false);
 	assert.deepEqual(config["packages"], {
 		".": { "exclude-paths": ["runner"] },
 		runner: {
@@ -90,6 +92,7 @@ test("release please owns independent npm and runner versions", async () => {
 	assert.match(hollywoodVersion, /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/);
 	assert.match(runnerVersion, /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/);
 	assert.deepEqual(manifest, { ".": hollywoodVersion, runner: runnerVersion });
+	assert.notEqual(`v${hollywoodVersion}`, `runner-v${runnerVersion}`);
 	assert.ok((await readFile("CHANGELOG.md", "utf8")).includes(`## [${hollywoodVersion}]`));
 	assert.ok((await readFile("runner/CHANGELOG.md", "utf8")).includes(`## ${runnerVersion} (`));
 });

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -15,6 +15,7 @@
 		}
 	},
 	"separate-pull-requests": true,
+	"force-tag-creation": true,
 	"include-v-in-tag": true,
 	"include-component-in-tag": false,
 	"bump-minor-pre-major": true,


### PR DESCRIPTION
## Summary

Create release tags before GitHub creates immutable releases. This allows the pending `v0.0.3` and `runner-v0.0.1` releases to finalize without changing either release ledger version.

## Validation

- Release Please 17.6.0 dry run emits `v0.0.3` and `runner-v0.0.1`.
- `npm run lint`.
- `npm run typecheck`.
- `npm test`: 212 passed, 6 skipped.
- `npm run check`.