### PR TITLE
fix(release): resolve immutable drafts by list

### DIFF
--- a/gha/release-actions.test.ts
+++ b/gha/release-actions.test.ts
@@ -148,17 +148,26 @@ test("draft release publication validates and publishes each component", async (
 					stdout: JSON.stringify({ ...release, draft: false, immutable: true }),
 				};
 			}
-			const tag = args[1]?.split("/").at(-1);
-			const release = releases.get(tag ?? "");
-			assert.ok(release !== undefined);
-			return { exitCode: 0, stderr: "", stdout: JSON.stringify(release) };
+			return {
+				exitCode: 0,
+				stderr: "",
+				stdout: JSON.stringify([[...releases.values()]]),
+			};
 		},
 		fs: releaseFiles("0.0.4", "0.0.1"),
 		runner: currentRunner(),
 	});
 
 	assert.deepEqual(commands, [
-		["gh", ["api", "repos/dedalus-labs/hollywood/releases/tags/v0.0.4"]],
+		[
+			"gh",
+			[
+				"api",
+				"--paginate",
+				"--slurp",
+				"repos/dedalus-labs/hollywood/releases?per_page=100",
+			],
+		],
 		[
 			"gh",
 			[
@@ -170,7 +179,6 @@ test("draft release publication validates and publishes each component", async (
 				"draft=false",
 			],
 		],
-		["gh", ["api", "repos/dedalus-labs/hollywood/releases/tags/runner-v0.0.1"]],
 		[
 			"gh",
 			[
@@ -199,12 +207,16 @@ test("draft release publication accepts an existing immutable release", async ()
 			return {
 				exitCode: 0,
 				stderr: "",
-				stdout: JSON.stringify({
-					draft: false,
-					id: 42,
-					immutable: true,
-					tag_name: "runner-v0.0.1",
-				}),
+			stdout: JSON.stringify([
+				[
+					{
+						draft: false,
+						id: 42,
+						immutable: true,
+						tag_name: "runner-v0.0.1",
+					},
+				],
+			]),
 			};
 		},
 		fs: releaseFiles("0.0.4", "0.0.1"),
@@ -226,17 +238,51 @@ test("draft release publication rejects a mutable published release", async () =
 			exec: async () => ({
 				exitCode: 0,
 				stderr: "",
-				stdout: JSON.stringify({
-					draft: false,
-					id: 41,
-					immutable: false,
-					tag_name: "v0.0.4",
-				}),
+				stdout: JSON.stringify([
+					[
+						{
+							draft: false,
+							id: 41,
+							immutable: false,
+							tag_name: "v0.0.4",
+						},
+					],
+				]),
 			}),
 			fs: releaseFiles("0.0.4", "0.0.1"),
 			runner: currentRunner(),
 		}),
 		/Release v0\.0\.4 is published but is not immutable/,
+	);
+});
+
+test.each([
+	{ count: 0, releases: [] },
+	{
+		count: 2,
+		releases: [
+			{ draft: true, id: 41, immutable: false, tag_name: "v0.0.4" },
+			{ draft: true, id: 42, immutable: false, tag_name: "v0.0.4" },
+		],
+	},
+])("draft release publication requires one matching release", async ({ count, releases }) => {
+	await assert.rejects(
+		runAction(publishDraftReleases, {
+			with: {
+				hollywoodTag: "v0.0.4",
+				repository: "dedalus-labs/hollywood",
+				runnerTag: "",
+				token: "token",
+			},
+			exec: async () => ({
+				exitCode: 0,
+				stderr: "",
+				stdout: JSON.stringify([releases]),
+			}),
+			fs: releaseFiles("0.0.4", "0.0.1"),
+			runner: currentRunner(),
+		}),
+		new RegExp(`Expected one GitHub release for v0\\.0\\.4; found ${count}`),
 	);
 });
 

--- a/gha/release-actions.ts
+++ b/gha/release-actions.ts
@@ -79,20 +79,27 @@ export const publishDraftReleases = action({
 		if (tags.length === 0) {
 			throw new Error("At least one release tag is required.");
 		}
-
 		for (const tag of tags) {
 			assertReleaseTag(tag);
-			const options = { env: { GH_TOKEN: input.token } };
-			const release = parseGitHubRelease(
-				(
-					await exec(
-						"gh",
-						["api", `repos/${input.repository}/releases/tags/${tag}`],
-						options,
-					)
-				).stdout,
-				tag,
-			);
+		}
+
+		const options = { env: { GH_TOKEN: input.token } };
+		const releases = parseGitHubReleasePages(
+			(
+				await exec(
+					"gh",
+					[
+						"api",
+						"--paginate",
+						"--slurp",
+						`repos/${input.repository}/releases?per_page=100`,
+					],
+					options,
+				)
+			).stdout,
+		);
+		for (const tag of tags) {
+			const release = releaseForTag(releases, tag);
 			if (!release.draft) {
 				assertImmutableRelease(release);
 				continue;
@@ -131,6 +138,13 @@ type GitHubRelease = Readonly<{
 
 const parseGitHubRelease = (source: string, expectedTag: string): GitHubRelease => {
 	const record = parseJsonRecord(source, `GitHub release ${expectedTag}`);
+	return parseGitHubReleaseRecord(record, expectedTag);
+};
+
+const parseGitHubReleaseRecord = (
+	record: Readonly<Record<string, unknown>>,
+	expectedTag: string,
+): GitHubRelease => {
 	const id = record["id"];
 	const tagName = record["tag_name"];
 	const draft = record["draft"];
@@ -145,6 +159,32 @@ const parseGitHubRelease = (source: string, expectedTag: string): GitHubRelease 
 		throw new Error(`GitHub release ${expectedTag} must contain draft and immutable booleans.`);
 	}
 	return { draft, id: id as number, immutable, tagName };
+};
+
+const parseGitHubReleasePages = (source: string): readonly Readonly<Record<string, unknown>>[] => {
+	const value = parseJsonValue(source, "GitHub release pages");
+	if (!Array.isArray(value)) {
+		throw new Error("GitHub release pages must contain a JSON array.");
+	}
+	return value.flatMap((page, pageIndex) => {
+		if (!Array.isArray(page)) {
+			throw new Error(`GitHub release page ${pageIndex} must contain a JSON array.`);
+		}
+		return page.map((release, releaseIndex) =>
+			jsonRecord(release, `GitHub release page ${pageIndex} item ${releaseIndex}`),
+		);
+	});
+};
+
+const releaseForTag = (
+	releases: readonly Readonly<Record<string, unknown>>[],
+	tag: string,
+): GitHubRelease => {
+	const matches = releases.filter((release) => release["tag_name"] === tag);
+	if (matches.length !== 1) {
+		throw new Error(`Expected one GitHub release for ${tag}; found ${matches.length}.`);
+	}
+	return parseGitHubReleaseRecord(matches[0] as Readonly<Record<string, unknown>>, tag);
 };
 
 const assertImmutableRelease = (release: GitHubRelease): void => {
@@ -194,12 +234,20 @@ const parseReleaseManifest = (source: string, name: string): ReleaseManifest => 
 };
 
 const parseJsonRecord = (source: string, name: string): Record<string, unknown> => {
+	return jsonRecord(parseJsonValue(source, name), name);
+};
+
+const parseJsonValue = (source: string, name: string): unknown => {
 	let value: unknown;
 	try {
 		value = JSON.parse(source) as unknown;
 	} catch (error: unknown) {
 		throw new Error(`${name} is not valid JSON.`, { cause: error });
 	}
+	return value;
+};
+
+const jsonRecord = (value: unknown, name: string): Record<string, unknown> => {
 	if (value === null || typeof value !== "object" || Array.isArray(value)) {
 		throw new Error(`${name} must contain a JSON object.`);
 	}


### PR DESCRIPTION
# Pull Request

## Summary

**What changed:**

The immutable release action now lists authenticated release pages once and resolves each expected component tag from that result. It rejects missing and duplicate matches.

**Why:**

GitHub returns `404 Not Found` from the release-by-tag endpoint while a release is still a draft. The authenticated release list includes drafts.

> [!IMPORTANT]
> Keep reviewed diffs small. If this adds more than 500 lines outside generated files or lockfiles, split it.

**Lines added, excluding generated files and lockfiles:** 124

## Test Plan

- [x] CLA/Vouch check passes, or this PR only updates `VOUCHED.td`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test`
- [x] `npm run build`
- [x] `npm run check`
- [ ] `npm run package`

## Generated Output

N/A. The generated action imports the updated typed implementation without metadata changes. `npm run check` reports all generated files unchanged.

## Repro / Showcase

Run `31845320611` created draft `runner-v0.0.1`, then the release-by-tag request returned `404 Not Found`. The release list API returned the same draft with ID `370846735`. Tests cover draft publication, immutable retries, mutable releases, zero matches, and duplicate matches.

## Release Impact

- [ ] Runtime/library behavior changed
- [ ] CLI behavior changed
- [ ] Generated YAML changed
- [ ] Package contents changed
- [ ] Documentation only
- [x] N/A

## Compatibility

The action uses `gh api --paginate --slurp`, which is available in the GitHub-hosted runner image. The public Hollywood API does not change.

## Reviewers

- Domain: Maintainer review required.
- Readability: Maintainer review required.

## Notes for Reviewers

Review the list pagination shape and the exactly-one-match invariant. The action performs one list request and one publish request per draft.

## Changelog

**2026-08-14**

Feedback received:

- Live recovery run showed that release-by-tag excludes drafts.

Changes made:

- Replaced release-by-tag lookup with authenticated paginated release discovery.
